### PR TITLE
Fix: Aya "randomly" permanently freezes on startup when using Canvas

### DIFF
--- a/src/aya/ext/graphics/Canvas.java
+++ b/src/aya/ext/graphics/Canvas.java
@@ -38,7 +38,6 @@ public class Canvas {
 	private JFrame _frame;
 	private boolean _show_on_refresh; // If true, call show() when refresh() is called, if false no-op
 	private AffineTransform _at;
-	private BufferStrategy _buf_strat;
 	
 	
 	public Canvas(String name, int width, int height, double scale) {
@@ -97,9 +96,6 @@ public class Canvas {
 			_frame.setLocationRelativeTo(comp);
 			_frame.setVisible(true);
 			
-			_frame.createBufferStrategy(2);
-			_buf_strat = _frame.getBufferStrategy();
-			
 			_frame.addWindowListener(new WindowAdapter() {
 				@Override
 		        public void windowClosing(WindowEvent event) {
@@ -107,9 +103,7 @@ public class Canvas {
 		        }
 			});
 		} else {
-			do {
-				_frame.repaint();
-			} while (_buf_strat.contentsLost());
+			_frame.repaint();
 		}
 	}
 	


### PR DESCRIPTION
Currently, when BufferStrategy::contentsLost occurs, Aya enters an infinite loop.  
From the javadoc for contentsLost: 'Returns whether the drawing buffer was lost since the last call to getDrawGraphics.'  
As far as I can tell, repainting does not cause the BufferStrategy to create a new Graphics instance / revalidate - so it remains `true`.

Removing the BufferStrategy showed no significant performance difference on my end and resolves this issue.

Alternatively, I have tried drawing to the BufferStrategy drawGraphics instead of the BufferedImage graphics, but that also gave no significant performance difference, so I've opted for the solution that removes code rather than adding some.