### PR TITLE
Mouse and keyboard examples

### DIFF
--- a/examples/canvas/attractor.aya
+++ b/examples/canvas/attractor.aya
@@ -7,7 +7,7 @@ import ::time
 color.colors.black :black;
 color.colors.white :white;
 
-"running!":P
+"Click to move the attractor":P
 1 :g;
 
 .# Mover
@@ -74,9 +74,14 @@ def attractor::show {self,
 .# Start with a black background
 black cvs.set_color
 0 0 cvs.width cvs.height cvs.fillrect
+cvs.show
 
 50 time.rate! :limiter;
 {
+  cvs.pressed_buttons 1 N 0:>\; {
+    cvs.mouse_pos a.:pos;
+  } ?
+
   .# Update movers
   ms :# {m,
     m.update

--- a/examples/canvas/color_typewriter.aya
+++ b/examples/canvas/color_typewriter.aya
@@ -1,0 +1,47 @@
+import ::canvas
+import ::time
+import ::color
+
+.# https://processing.org/examples/keyboardfunctions.html
+.# Based off the original 'Color Typewriter' concept by John Maeda.
+
+12 :num_tiles;  .# Number of tiles on the canvas
+40 :tile_width; .# width of each tile
+
+.# List to store tiles in
+color.colors.white num_tiles 2^ L :grid;
+0:index;
+
+{,
+    num_tiles :width
+    num_tiles :height
+    tile_width :scale
+} canvas! :cvs;
+cvs.show
+
+60 time.rate! :limiter;
+{
+    cvs.typed_chars :# {ch,
+        .# Tile hue is based of its key code
+        (ch :' 23* 360%, 0.8, 0.8) color.newhsv grid.:[index num_tiles 2^ %];
+        index 1+ :index;
+    };
+
+    cvs.clear
+
+    .# Draw the grid
+    grid.enumerate :# {e : index color x y,
+      e.[0] :index;
+      e.[1] :color;
+
+      index num_tiles %  :x;
+      index num_tiles .% :y;
+
+      color cvs.set_color
+      x y cvs.point
+    };
+
+    cvs.show
+    limiter.sleep
+    cvs.isopen
+} W

--- a/examples/canvas/mouse.aya
+++ b/examples/canvas/mouse.aya
@@ -1,0 +1,27 @@
+import ::canvas
+import ::time
+
+{,} canvas! :cvs;
+cvs.show
+
+60 time.rate! :limiter;
+{
+    .# Get pressed buttons
+    cvs.pressed_buttons :mouse_buttons;
+    mouse_buttons 1 N0:>\; {
+        1:fill;
+    } {
+        0:fill;
+    } .?
+
+    .# Get mouse position
+    cvs.get_mouse_pos :mouse_pos;
+
+    cvs.clear
+    mouse_pos.x mouse_pos.y 10
+    fill {cvs.fillcircle} {cvs.circle} .?
+
+    cvs.show
+    limiter.sleep
+    cvs.isopen
+} W

--- a/examples/canvas/mouse.aya
+++ b/examples/canvas/mouse.aya
@@ -1,6 +1,8 @@
 import ::canvas
 import ::time
 
+.# A simple mouse input example
+
 {,} canvas! :cvs;
 cvs.show
 
@@ -15,7 +17,7 @@ cvs.show
     } .?
 
     .# Get mouse position
-    cvs.get_mouse_pos :mouse_pos;
+    cvs.mouse_pos :mouse_pos;
 
     cvs.clear
     mouse_pos.x mouse_pos.y 10

--- a/src/aya/ext/graphics/Canvas.java
+++ b/src/aya/ext/graphics/Canvas.java
@@ -15,6 +15,8 @@ import javax.imageio.ImageIO;
 import javax.swing.JFrame;
 import javax.swing.JPanel;
 
+import aya.exceptions.runtime.ValueError;
+
 /**
  * A very basic plotting tool. Plots an arbitrary number of doubles to a graph
  * where the x location is the location in the array and the y location
@@ -70,11 +72,19 @@ public class Canvas {
 	}
 
 	public CanvasCursorListener getCursorListener() {
-		return _cursor_listener;
+		if (_cursor_listener != null) {
+			return _cursor_listener;
+		} else {
+			throw new ValueError("Cannot get mouse information: canvas has not yet been opened");
+		}
 	}
 
 	public CanvasKeyListener getKeyListener() {
-		return _key_listener;
+		if (_key_listener != null) {
+			return _key_listener;
+		} else {
+			throw new ValueError("Cannot get keyboard information: canvas has not yet been opened");
+		}
 	}
 
 	public void setShowOnRefresh(boolean b) {

--- a/src/aya/obj/list/List.java
+++ b/src/aya/obj/list/List.java
@@ -730,7 +730,13 @@ public class List extends Obj {
 	 * into a NumberList)
 	 */
 	public void mutSetIndexed(int i, Obj o) {
-		mutSetExact(index(i, length()), o);
+		final int len = length();
+		final int idx = index(i, len);
+		if (idx < 0 || idx >= len) {
+			throw new IndexError(this, Num.fromInt(idx));
+		} else {
+			mutSetExact(idx, o);
+		}
 	}
 	
 	

--- a/std/canvas.aya
+++ b/std/canvas.aya
@@ -162,3 +162,7 @@ def canvas::get_mouse_pos {self : move,
 def canvas::pressed_buttons {self,
     self.id :{graphics.pressed_buttons}
 }
+
+def canvas::typed_chars {self,
+    self.id :{graphics.typed_chars}
+}

--- a/std/canvas.aya
+++ b/std/canvas.aya
@@ -21,6 +21,9 @@ def canvas::__init__ {params::dict self : color^,
     params.width self.:width;
     params.height self.:height;
 
+    .# Input
+    {, -1:x -1:y } self.:_last_mouse_pos;
+
     .# ::new params 0 :{graphics.MG} self.:id ;
     params :{graphics.new} self.:id ;
 }
@@ -140,4 +143,22 @@ def canvas::viewmat {data self,
 .# Block until the canvas is closed
 def canvas::wait {self,
     { 100:Z self.isopen } W
+}
+
+def canvas::move_events {self,
+    self.id :{graphics.move_events}
+}
+
+.# Get the most recent mouse x/y
+.# return {, -1:x -1:y } if no updates
+def canvas::get_mouse_pos {self : move,
+    self.move_events :move;
+    move E 0 > {
+        move.[-1] self.:_last_mouse_pos;
+    } ?
+    self._last_mouse_pos
+}
+
+def canvas::pressed_buttons {self,
+    self.id :{graphics.pressed_buttons}
 }

--- a/std/canvas.aya
+++ b/std/canvas.aya
@@ -22,7 +22,7 @@ def canvas::__init__ {params::dict self : color^,
     params.height self.:height;
 
     .# Input
-    {, -1:x -1:y } self.:_last_mouse_pos;
+    [-1 -1] self.:_last_mouse_pos;
 
     .# ::new params 0 :{graphics.MG} self.:id ;
     params :{graphics.new} self.:id ;
@@ -150,11 +150,11 @@ def canvas::move_events {self,
 }
 
 .# Get the most recent mouse x/y
-.# return {, -1:x -1:y } if no updates
-def canvas::get_mouse_pos {self : move,
+.# return [-1 -1] if no updates
+def canvas::mouse_pos {self : move,
     self.move_events :move;
     move E 0 > {
-        move.[-1] self.:_last_mouse_pos;
+        [move.[-1] :&.x\.y] self.:_last_mouse_pos;
     } ?
     self._last_mouse_pos
 }


### PR DESCRIPTION
  - Standard library
    - Wrap mouse & keyboard `:{graphics.*}` functions in `canvas`
  - Examples
    - [new] Simple mouse input (`canvas/mouse.aya`)
    - [new] Color Typewriter (`canvas/color_typewriter.aya`) 
    - [updated] Move attractor with mouse (`canvas/attractor.aya`)
  - Bug fixes
    - Fix uncaught index error when setting index of list
    - Fix `NullPointerException` thrown when accessing canvas input before displaying the canvas 