### PR TITLE
WIP: `ListImpl` for `double[]`

### DIFF
--- a/base/exception.aya
+++ b/base/exception.aya
@@ -5,7 +5,7 @@ def exception::__repr__ {self,
 }
 
 {,
-    ::ex :O :K :# {type,
+    ::ex Ma :K :# {type,
         {msg : exception^ , msgP type exception! .D } {, type:type} .+ type :=
     };
 

--- a/base/list.aya
+++ b/base/list.aya
@@ -134,7 +134,7 @@
     { .E @ \- 0.< @\L J }:rpad;
 
     .#? ::list ::num .pad\n 2d padding
-    {n l, lEn+$n+ \2:$ l\.>\.< \#.< \#.>}:pad;
+    {n l, l:En+$n+\~ l\#.>\.> \~@ \#.<\.<}:pad;
 
 
     .#? ::any ::list .surround\n  append A to the front and back of L
@@ -177,6 +177,8 @@
         '\n' %                              .# Join with newlines
     }
 
+    {\.S}:rotate_rows;
+    {\0\J.S}:rotate_cols;
 }
 .# Merge with list metatable
 [] .M \.+

--- a/base/sym.aya
+++ b/base/sym.aya
@@ -49,7 +49,7 @@
 
     {,
         .# Get the overload list for all ops
-        ::ops :O :#{.overload}
+        ::ops Ma :#{.overload}
         .# Get all ops with non-zero length overloads
         .[{E 0 = !}]
         .# For each overload list

--- a/src/aya/ext/graphics/Canvas.java
+++ b/src/aya/ext/graphics/Canvas.java
@@ -1,10 +1,15 @@
 package aya.ext.graphics;
 
-import java.awt.*;
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.Container;
+import java.awt.Dimension;
+import java.awt.Graphics;
+import java.awt.Graphics2D;
+import java.awt.RenderingHints;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
 import java.awt.geom.AffineTransform;
-import java.awt.image.BufferStrategy;
 import java.awt.image.BufferedImage;
 import java.io.BufferedReader;
 import java.io.File;

--- a/src/aya/ext/image/ReadImageInstruction.java
+++ b/src/aya/ext/image/ReadImageInstruction.java
@@ -13,7 +13,7 @@ import aya.exceptions.runtime.TypeError;
 import aya.instruction.named.NamedInstruction;
 import aya.obj.Obj;
 import aya.obj.block.Block;
-import aya.obj.list.numberlist.NumberItemList;
+import aya.obj.list.numberlist.NumberList;
 
 public class ReadImageInstruction extends NamedInstruction {
 	
@@ -54,7 +54,7 @@ public class ReadImageInstruction extends NamedInstruction {
 		 DataBufferByte data   = (DataBufferByte) raster.getDataBuffer();
 
 		 return new AyaImage(
-				 NumberItemList.fromBytes(data.getData()),
+				 NumberList.fromBytes(data.getData()),
 				 bufferedImage.getWidth(),
 				 bufferedImage.getHeight());
 	}		

--- a/src/aya/ext/la/MatMulInstruction.java
+++ b/src/aya/ext/la/MatMulInstruction.java
@@ -9,7 +9,6 @@ import aya.instruction.named.NamedInstruction;
 import aya.obj.Obj;
 import aya.obj.block.Block;
 import aya.obj.list.List;
-import aya.obj.list.numberlist.NumberItemList;
 import aya.obj.list.numberlist.NumberList;
 import aya.obj.number.Num;
 import aya.obj.number.NumberMath;
@@ -46,10 +45,10 @@ public class MatMulInstruction extends NamedInstruction {
 		}
 	}
 	
-	private static ArrayList<NumberItemList> newEmpty(int rows, int cols) {
-		ArrayList<NumberItemList> out = new ArrayList<NumberItemList>();
+	private static ArrayList<NumberList> newEmpty(int rows, int cols) {
+		ArrayList<NumberList> out = new ArrayList<NumberList>();
 		for (int r = 0; r < rows; r++) {
-			out.add(new NumberItemList(Num.ZERO, cols));
+			out.add(NumberList.repeat(Num.ZERO, cols));
 		}
 		return out;
 	}
@@ -62,7 +61,7 @@ public class MatMulInstruction extends NamedInstruction {
 		int p = b.length();
 		int q = Casting.asList(b.getExact(0)).length();
 		// C is (m x q)
-		ArrayList<NumberItemList> c = newEmpty(m, q);
+		ArrayList<NumberList> c = newEmpty(m, q);
 		
 		// Store b_k casting operations so we don't have to do it in the innermost loop
 		ArrayList<NumberList> b_k = new ArrayList<NumberList>();
@@ -83,7 +82,7 @@ public class MatMulInstruction extends NamedInstruction {
 		
 		// Convert to List
 		List out = new List();
-		for (NumberItemList x : c) out.mutAdd(new List(x));
+		for (NumberList x : c) out.mutAdd(new List(x));
 		return out;
 	}
 

--- a/src/aya/instruction/op/ColonOps.java
+++ b/src/aya/instruction/op/ColonOps.java
@@ -36,7 +36,7 @@ import aya.obj.character.Char;
 import aya.obj.dict.Dict;
 import aya.obj.list.List;
 import aya.obj.list.Str;
-import aya.obj.list.numberlist.NumberItemList;
+import aya.obj.list.numberlist.DoubleList;
 import aya.obj.list.numberlist.NumberList;
 import aya.obj.list.numberlist.NumberListOp;
 import aya.obj.number.Num;
@@ -229,12 +229,12 @@ class OP_Colon_Quote extends OpInstruction {
 			block.push(Num.fromInt(c & 0xff));
 		} else if (a.isa(STR)) {
 			Str s = asStr(a);
-			ArrayList<Number> nums = new ArrayList<Number>(s.length());
 			byte[] bytes = s.getBytes();
-			for (byte b : bytes) {
-				nums.add(Num.fromByte(b));
+			double[] nums = new double[bytes.length];
+			for (int i = 0; i < bytes.length; i++) {
+				nums[i] = bytes[i];
 			}
-			block.push(new List(new NumberItemList(nums)));
+			block.push(new List(new DoubleList(nums)));
 		} else {
 			throw new TypeError(this, a);
 		}

--- a/src/aya/instruction/op/ColonOps.java
+++ b/src/aya/instruction/op/ColonOps.java
@@ -15,17 +15,12 @@ import static aya.util.Casting.asSymbol;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
 
 import aya.Aya;
 import aya.ReprStream;
-import aya.exceptions.ex.AyaException;
 import aya.exceptions.ex.NotAnOperatorError;
 import aya.exceptions.ex.ParserException;
-import aya.exceptions.ex.StaticAyaExceptionList;
 import aya.exceptions.runtime.AssertError;
-import aya.exceptions.runtime.AyaRuntimeException;
 import aya.exceptions.runtime.MathError;
 import aya.exceptions.runtime.TypeError;
 import aya.exceptions.runtime.UnimplementedError;
@@ -984,52 +979,51 @@ class OP_Colon_O extends OpInstruction {
 	
 	public OP_Colon_O() {
 		init(":O");
-		arg("J", "Aya meta information");
+		arg("AAB", "apply (2-arg)");
 	}
+
+	private class BlockOpInstruction extends OpInstruction {
+		private final Block _block;
+		public BlockOpInstruction(Block block) {
+			_block = block;
+		}
+		@Override
+		public void execute(Block block) {
+			final Obj b = block.pop();
+			final Obj a = block.pop();
+			block.push(exec2arg(a, b));
+		}
+		@Override
+		public Obj exec2arg(final Obj a, final Obj b) {
+			Obj res;
+			if ((res = VectorizedFunctions.vectorize2arg(this, a, b)) != null) {
+				return res;
+			} else {
+				Block blk = _block.duplicate();
+				blk.push(a);
+				blk.push(b);
+				blk.eval();
+				return blk.pop();
+			}
+		}
+	}
+
 
 	@Override
-	public void execute (Block block) {		
-		Obj a = block.pop();
-		
-		if (a.isa(SYMBOL)) {
-			Symbol sym = (Symbol)a;
-			if (sym.name().equals("ops")) {
-				block.push(OpInfo.getDict());
-			} else if (sym.name().equals("ex")) {
-				block.push(getExInfo());
-			} else {
-				throw new ValueError("':O': Unknown symbol " + sym.name());
-			}
+	public void execute(final Block block) {
+		final Obj c = block.pop(); // block
+		final Obj b = block.pop();
+		final Obj a = block.pop();
+
+		if (c.isa(Obj.BLOCK)) {
+			final BlockOpInstruction block_op = new BlockOpInstruction(Casting.asBlock(c));
+			block.push(VectorizedFunctions.vectorize2arg(block_op, a, b));
 		} else {
-			throw new TypeError(this, a);
-		}
-	}
-	
-	/**
-	 * Get list of all built-in exception types
-	 * @return
-	 */
-	public Dict getExInfo() {
-		Dict ex_info = new Dict();
-		HashMap<Symbol, AyaException> exceptions = StaticAyaExceptionList.getExceptions();
-		HashMap<Symbol, AyaRuntimeException> rt_exceptions = StaticAyaExceptionList.getRuntimeExceptions();
-		
-		for (Map.Entry<Symbol, AyaException> entry : exceptions.entrySet()) {
-			Dict d = new Dict();
-			d.set(SymbolConstants.TYPE, entry.getValue().typeSymbol());
-			d.set(SymbolConstants.SOURCE, SymbolConstants.EXCEPTION);
-			ex_info.set(entry.getKey(), d);
+			throw new TypeError(this, c, b, a);
 		}
 
-		for (Map.Entry<Symbol, AyaRuntimeException> entry : rt_exceptions.entrySet()) {
-			Dict d = new Dict();
-			d.set(SymbolConstants.TYPE, entry.getValue().typeSymbol());
-			d.set(SymbolConstants.SOURCE, SymbolConstants.RUNTIME_EXCEPTION);
-			ex_info.set(entry.getKey(), d);
-		}
-
-		return ex_info;
 	}
+
 }
 
 

--- a/src/aya/instruction/op/DotOps.java
+++ b/src/aya/instruction/op/DotOps.java
@@ -53,7 +53,6 @@ import aya.obj.dict.DictIndexing;
 import aya.obj.list.List;
 import aya.obj.list.ListRangeUtils;
 import aya.obj.list.Str;
-import aya.obj.list.numberlist.NumberItemList;
 import aya.obj.list.numberlist.NumberList;
 import aya.obj.list.numberlist.NumberListOp;
 import aya.obj.number.BaseConversion;
@@ -1284,12 +1283,12 @@ class OP_Dot_R extends OpInstruction {
 			for (int i = 0; i < count; i++) {
 				nums.add(from);
 			}
-			return new NumberItemList(nums);
+			return NumberList.fromNumberAL(nums);
 		} else {
 			Number a = NumberMath.sub(to, from);
 			Number b = NumberMath.sub(steps, Num.ONE);
 			Number inc = NumberMath.div(a, b);
-			NumberItemList out = new NumberItemList(from, to, inc);
+			NumberList out = NumberList.range(from, to, inc);
 
 			// Rounding error may cause off-by-one
 			int expected_len = steps.toInt();

--- a/src/aya/instruction/op/DotOps.java
+++ b/src/aya/instruction/op/DotOps.java
@@ -1324,17 +1324,17 @@ class OP_Dot_S extends OpInstruction {
 		final Obj b = block.pop();
 
 		if (a.isa(Obj.NUM) && b.isa(Obj.LIST)) {
-			asList(b).mutRotate(asNumber(a).toInt());
-			block.push(b);
+			List out = asList(b).rotate(asNumber(a).toInt());
+			block.push(out);
 		} else if (a.isa(Obj.LIST) && b.isa(LIST)) {
 			final NumberList amount = asList(a).toNumberList();
 			List list = asList(b);
 			if (amount.length() == 1) {
-				list.mutRotate(amount.get(0).toInt());
-				block.push(b);
+				List out = list.rotate(amount.get(0).toInt());
+				block.push(out);
 			} else if (amount.length() == 2) {
-				rotate(list, amount.get(0).toInt(), amount.get(1).toInt());
-				block.push(b);
+				List out = rotate(list, amount.get(0).toInt(), amount.get(1).toInt());
+				block.push(out);
 			} else {
 				throw new ValueError(".S rotation amount must be length 1 or 2");
 			}
@@ -1343,14 +1343,15 @@ class OP_Dot_S extends OpInstruction {
 		}
 	}
 
-	private void rotate(List l, int rows, int cols) {
-		l.mutRotate(rows);
+	private List rotate(List l, int rows, int cols) {
+		l = l.rotate(rows);
 		for (int i = 0; i < l.length(); i++) {
 			Obj x = l.getExact(i);
 			if (x.isa(Obj.LIST)) {
-				asList(x).mutRotate(cols);
+				l.mutSetExact(i, asList(x).rotate(cols));
 			}
 		}
+		return l;
 	}
 }
 

--- a/src/aya/instruction/op/MiscOps.java
+++ b/src/aya/instruction/op/MiscOps.java
@@ -9,9 +9,14 @@ import static aya.obj.Obj.STR;
 import static aya.util.Casting.asNumber;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 import aya.Aya;
+import aya.exceptions.ex.AyaException;
 import aya.exceptions.ex.NotAnOperatorError;
+import aya.exceptions.ex.StaticAyaExceptionList;
+import aya.exceptions.runtime.AyaRuntimeException;
 import aya.exceptions.runtime.TypeError;
 import aya.exceptions.runtime.UnimplementedError;
 import aya.exceptions.runtime.ValueError;
@@ -30,6 +35,8 @@ import aya.obj.number.FractionNum;
 import aya.obj.number.Num;
 import aya.obj.number.Number;
 import aya.obj.number.NumberMath;
+import aya.obj.symbol.Symbol;
+import aya.obj.symbol.SymbolConstants;
 import aya.util.Casting;
 import aya.util.NamedCharacters;
 import aya.util.StringUtils;
@@ -109,7 +116,7 @@ public class MiscOps {
 		/* 94 ^  */ null,
 		/* 95 _  */ null,
 		/* 96 `  */ null,
-		/* 97 a  */ null,
+		/* 97 a  */ new OP_Ma(),
 		/* 98 b  */ new OP_Mb(),
 		/* 99 c  */ new OP_Cosine(),
 		/* 100 d */ new OP_CastDouble(),
@@ -450,6 +457,61 @@ class OP_Atangent extends OpInstruction {
 		}
 	}
 }
+
+// a - 97
+class OP_Ma extends OpInstruction {
+	
+	public OP_Ma() {
+		init("Ma");
+		arg("J", "Aya meta information");
+	}
+
+	@Override
+	public void execute (Block block) {		
+		Obj a = block.pop();
+		
+		if (a.isa(Obj.SYMBOL)) {
+			Symbol sym = (Symbol)a;
+			if (sym.name().equals("ops")) {
+				block.push(OpInfo.getDict());
+			} else if (sym.name().equals("ex")) {
+				block.push(getExInfo());
+			} else {
+				throw new ValueError("'Ma': Unknown symbol " + sym.name());
+			}
+		} else {
+			throw new TypeError(this, a);
+		}
+	}
+	
+	/**
+	 * Get list of all built-in exception types
+	 * @return
+	 */
+	public Dict getExInfo() {
+		Dict ex_info = new Dict();
+		HashMap<Symbol, AyaException> exceptions = StaticAyaExceptionList.getExceptions();
+		HashMap<Symbol, AyaRuntimeException> rt_exceptions = StaticAyaExceptionList.getRuntimeExceptions();
+		
+		for (Map.Entry<Symbol, AyaException> entry : exceptions.entrySet()) {
+			Dict d = new Dict();
+			d.set(SymbolConstants.TYPE, entry.getValue().typeSymbol());
+			d.set(SymbolConstants.SOURCE, SymbolConstants.EXCEPTION);
+			ex_info.set(entry.getKey(), d);
+		}
+
+		for (Map.Entry<Symbol, AyaRuntimeException> entry : rt_exceptions.entrySet()) {
+			Dict d = new Dict();
+			d.set(SymbolConstants.TYPE, entry.getValue().typeSymbol());
+			d.set(SymbolConstants.SOURCE, SymbolConstants.RUNTIME_EXCEPTION);
+			ex_info.set(entry.getKey(), d);
+		}
+
+		return ex_info;
+	}
+
+}
+
 
 
 // b - 98

--- a/src/aya/instruction/op/MiscOps.java
+++ b/src/aya/instruction/op/MiscOps.java
@@ -27,7 +27,7 @@ import aya.obj.block.Block;
 import aya.obj.character.Char;
 import aya.obj.dict.Dict;
 import aya.obj.list.List;
-import aya.obj.list.numberlist.NumberItemList;
+import aya.obj.list.numberlist.DoubleList;
 import aya.obj.list.numberlist.NumberList;
 import aya.obj.list.numberlist.NumberListOp;
 import aya.obj.number.ComplexNum;
@@ -795,7 +795,7 @@ class OP_Primes extends OpInstruction {
 			if (i < 0) {
 				throw new ValueError("Mp: Input must be positive");
 			}
-			block.push(new List(NumberItemList.primes(i)));
+			block.push(new List(DoubleList.primes(i)));
 		} else {
 			throw new TypeError(this, a);
 		}

--- a/src/aya/instruction/op/Ops.java
+++ b/src/aya/instruction/op/Ops.java
@@ -50,7 +50,6 @@ import aya.obj.list.GenericList;
 import aya.obj.list.List;
 import aya.obj.list.ListRangeUtils;
 import aya.obj.list.Str;
-import aya.obj.list.numberlist.NumberItemList;
 import aya.obj.list.numberlist.NumberList;
 import aya.obj.list.numberlist.NumberListOp;
 import aya.obj.number.BigNum;
@@ -1113,7 +1112,7 @@ class OP_L extends OpInstruction {
 			if (item.isa(CHAR)) {
 				block.push( new List(new Str( ((Char)item).charValue(), repeats)) );
 			} else if (item.isa(NUMBER)) {
-				block.push( new List(new NumberItemList((Number)item, repeats)) );
+				block.push( new List(NumberList.repeat((Number)item, repeats)) );
 			} else  {
 				block.push( new List(new GenericList(item, repeats)) );
 			}

--- a/src/aya/obj/Obj.java
+++ b/src/aya/obj/Obj.java
@@ -68,6 +68,8 @@ public abstract class Obj {
 			return "STR";
 		case NUMBERITEMLIST:
 			return "NUMBERITEMLIST";
+		case DOUBLELIST:
+			return "DOUBLELIST";
 		case LIST:
 			return "LIST";
 		case BLOCK: 
@@ -101,6 +103,7 @@ public abstract class Obj {
 		case NUMBERITEMLIST : return SymbolConstants.LIST;
 		case OBJLIST : return SymbolConstants.LIST;
 		case STRLIST : return SymbolConstants.LIST;
+		case DOUBLELIST : return SymbolConstants.LIST;
 		
 		case SYMBOL : return SymbolConstants.SYM;
 		case STR : return SymbolConstants.STR;

--- a/src/aya/obj/Obj.java
+++ b/src/aya/obj/Obj.java
@@ -33,6 +33,8 @@ public abstract class Obj {
 	public static final byte NUMBERITEMLIST = 23;
 	public static final byte OBJLIST = 24;
 	public static final byte STRLIST = 25;
+	public static final byte DOUBLELIST = 26;
+
 
 	public static final byte CHAR = 3;
 	

--- a/src/aya/obj/list/GenericList.java
+++ b/src/aya/obj/list/GenericList.java
@@ -172,8 +172,10 @@ public class GenericList extends ListImpl {
 	}
 
 	@Override
-	public void rotate(int n) {
-		ListAlgorithms.rotate(_list, n);
+	public ListImpl rotate(int n) {
+		ArrayList<Obj> l = new ArrayList<>(_list); // Copy
+		ListAlgorithms.rotate(l, n);
+		return new GenericList(l).promote();
 	}
 
 	@Override

--- a/src/aya/obj/list/GenericList.java
+++ b/src/aya/obj/list/GenericList.java
@@ -9,7 +9,7 @@ import aya.ReprStream;
 import aya.exceptions.runtime.ValueError;
 import aya.obj.Obj;
 import aya.obj.character.Char;
-import aya.obj.list.numberlist.NumberItemList;
+import aya.obj.list.numberlist.NumberList;
 import aya.obj.number.Num;
 import aya.obj.number.Number;
 import aya.util.Casting;
@@ -71,7 +71,7 @@ public class GenericList extends ListImpl {
 	}
 	
 	@Override
-	public NumberItemList toNumberList() {
+	public NumberList toNumberList() {
 		ArrayList<Number> out = new ArrayList<Number>(_list.size());
 		for (int i = 0; i < _list.size(); i++) {
 			if (!_list.get(i).isa(Obj.NUMBER)) {
@@ -80,7 +80,7 @@ public class GenericList extends ListImpl {
 				out.add((Number)(_list.get(i)));
 			}
 		}
-		return new NumberItemList(out);
+		return NumberList.fromNumberAL(out);
 	}
 
 	/** If all items in the list are a Number, convert this list to a
@@ -202,8 +202,8 @@ public class GenericList extends ListImpl {
 	}
 
 	@Override
-	public NumberItemList findAll(Obj o) {
-		return new NumberItemList(ListAlgorithms.findAll(_list, o));
+	public NumberList findAll(Obj o) {
+		return NumberList.fromNumberAL(ListAlgorithms.findAll(_list, o));
 	}
 
 	@Override
@@ -306,7 +306,7 @@ public class GenericList extends ListImpl {
 			if (head.isa(Obj.LIST)) {
 				return new List(new GenericList(asList(head).sameShapeNull(), length()));
 			} else {
-				return new List(new NumberItemList(Num.ZERO, length()));
+				return new List(NumberList.repeat(Num.ZERO, length()));
 			}
 		}
 	}

--- a/src/aya/obj/list/GenericList.java
+++ b/src/aya/obj/list/GenericList.java
@@ -9,6 +9,7 @@ import aya.ReprStream;
 import aya.exceptions.runtime.ValueError;
 import aya.obj.Obj;
 import aya.obj.character.Char;
+import aya.obj.list.numberlist.DoubleList;
 import aya.obj.list.numberlist.NumberList;
 import aya.obj.number.Num;
 import aya.obj.number.Number;
@@ -20,18 +21,20 @@ public class GenericList extends ListImpl {
 	private ArrayList<Obj> _list;
 	private int _chars;
 	private int _nums;
+	private int _doubles;
 	
 	public GenericList(ArrayList<Obj> l) {
 		_list = l;
 		_chars = 0;
 		_nums = 0;
+		_doubles = 0;
 		
 		for (Obj o : _list) {
 			incCharNumCounter(o);
 		}
 	}
 	
-	/** Create a new numeric list by repeating item, repeats times. 
+	/** Create a new list by repeating item, repeats times. 
 	 * Uses deepcopy() to copy the items into the list 
 	 */
 	public GenericList(Obj item, int repeats) {
@@ -50,16 +53,6 @@ public class GenericList extends ListImpl {
 	////////////////////////////
 	// CONVERSION & PROMOTION //
 	////////////////////////////
-	
-	/** Return true if all elements are of type Char */
-	private boolean isStr() {
-		return _list.size() != 0 && _chars == _list.size();
-	}
-	
-	/** Return true if all elements are of type Number */
-	private boolean isNumericList() {
-		return _list.size() != 0 && _nums == _list.size();
-	}
 	
 	/** Convert to string assuming all items are Char */
 	private Str asStr() {
@@ -83,6 +76,16 @@ public class GenericList extends ListImpl {
 		return NumberList.fromNumberAL(out);
 	}
 
+	private DoubleList toDoubleList() {
+		final int len = length();
+		double[] ds = new double[len];
+		for (int i = 0; i < len; i++) {
+			ds[i] = ((Number)(_list.get(i))).toDouble();
+		}
+		return new DoubleList(ds);
+	}
+
+
 	/** If all items in the list are a Number, convert this list to a
 	 * NumericItemList, if all items in the list are a Char, convert
 	 * to a Str, otherwise, return <code>this</code>.
@@ -90,14 +93,20 @@ public class GenericList extends ListImpl {
 	 * @return
 	 */
 	public ListImpl promote() {
-		if (isStr()) {
-			return asStr();
-		} else if (isNumericList()) {
-			return toNumberList();
-		} else {
+		final int len = _list.size();
+		if (len == 0) {
 			return this;
+		} else {
+			if (_chars == len) {
+				return asStr();
+			} else if (_doubles == len) {
+				return toDoubleList();
+			} else if (_nums == len) {
+				return toNumberList();
+			} else {
+				return this;
+			}
 		}
-		
 	}
 	
 	
@@ -393,6 +402,9 @@ public class GenericList extends ListImpl {
 	private void incCharNumCounter(Obj o) {
 		if (o.isa(Obj.CHAR)) {
 			_chars += 1;
+		} else if (o.isa(Obj.NUM)) {
+			_nums += 1;
+			_doubles += 1;
 		} else if (o.isa(Obj.NUMBER)) {
 			_nums += 1;
 		} 
@@ -401,6 +413,9 @@ public class GenericList extends ListImpl {
 	private void decCharNumCounter(Obj o) {
 		if (o.isa(Obj.CHAR)) {
 			_chars -= 1;
+		} else if (o.isa(Obj.NUM)) {
+			_nums -= 1;
+			_doubles -= 1;
 		} else if (o.isa(Obj.NUMBER)) {
 			_nums -= 1;
 		} 

--- a/src/aya/obj/list/List.java
+++ b/src/aya/obj/list/List.java
@@ -470,6 +470,11 @@ public class List extends Obj {
 	public Obj tail() {
 		return _list.tail();
 	}
+
+	/** Return a rotated copy of the list */
+	public List rotate(int n) {
+		return new List(_list.rotate(n));
+	}
 	
 	/** Remove and return the head of the list */
 	public Obj mutPop() {
@@ -490,10 +495,6 @@ public class List extends Obj {
 		_list.reverse();
 	}
 
-	/** Rotate the list in place */
-	public void mutRotate(int n) {
-		_list.rotate(n);
-	}
 	
 	/** Sort the list */
 	public void mutSort() {

--- a/src/aya/obj/list/List.java
+++ b/src/aya/obj/list/List.java
@@ -14,6 +14,7 @@ import aya.exceptions.runtime.ValueError;
 import aya.instruction.DataInstruction;
 import aya.obj.Obj;
 import aya.obj.block.Block;
+import aya.obj.list.numberlist.DoubleList;
 import aya.obj.list.numberlist.NumberList;
 import aya.obj.number.Num;
 import aya.util.Casting;
@@ -159,31 +160,42 @@ public class List extends Obj {
 	private List _transpose2d() {
 		// Convert to list of lists
 		ArrayList<List> lists = new ArrayList<List>(length());
+		ArrayList<DoubleList> double_lists = new ArrayList<DoubleList>();
+		boolean all_double_lists = true;
 		for (int i = 0; i < length(); i++) {
-			lists.add( Casting.asList(getExact(i)) );
+			List list = Casting.asList(getExact(i));
+			if (all_double_lists && list.isa(Obj.DOUBLELIST)) {
+				double_lists.add((DoubleList)list.toNumberList());
+			} else {
+				all_double_lists = false;
+			}
+			lists.add(list);
 		}
-		
-		int cols = lists.get(0).length();
-		
-		if (cols == 0) {
+
+		if (all_double_lists) {
+			return DoubleList.transpose2d(double_lists);
+		} else {
+			int cols = lists.get(0).length();
+			
+			if (cols == 0) {
+				List out = new List();
+				out.mutAdd(new List());
+				return out;
+			}
+			
 			List out = new List();
-			out.mutAdd(new List());
+			for (int i = 0; i < cols; i++) {
+				List os = new List();
+				for (int j = 0; j < lists.size(); j++) {
+					os.mutAdd(lists.get(j).getExact(i));
+				}
+				out.mutAdd(os);
+			}
+			
 			return out;
 		}
-		
-		List out = new List();
-		for (int i = 0; i < cols; i++) {
-			List os = new List();
-			for (int j = 0; j < lists.size(); j++) {
-				os.mutAdd(lists.get(j).getExact(i));
-			}
-			out.mutAdd(os);
-		}
-		
-		return out;
 	}
-	
-	
+
 	//Yes I know this is gross, i'll fix it later...
 	public List reshape(NumberList dims) {
 		if (dims.length() == 0)

--- a/src/aya/obj/list/List.java
+++ b/src/aya/obj/list/List.java
@@ -6,7 +6,6 @@ import static aya.util.Casting.asNumber;
 import static aya.util.Casting.asNumberList;
 
 import java.util.ArrayList;
-import java.util.ListResourceBundle;
 
 import aya.ReprStream;
 import aya.exceptions.runtime.IndexError;
@@ -17,7 +16,6 @@ import aya.obj.Obj;
 import aya.obj.block.Block;
 import aya.obj.list.numberlist.NumberList;
 import aya.obj.number.Num;
-import aya.obj.number.Number;
 import aya.util.Casting;
 import aya.util.Pair;
 

--- a/src/aya/obj/list/ListAlgorithms.java
+++ b/src/aya/obj/list/ListAlgorithms.java
@@ -1,7 +1,6 @@
 package aya.obj.list;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 
 import aya.ReprStream;
@@ -283,6 +282,16 @@ public class ListAlgorithms {
 		stream.print("[ ");
 		for (T o : list) {
 			o.repr(stream);
+			stream.print(" ");
+		}
+		stream.print("]");
+		return stream;
+    }
+
+	public static ReprStream reprCompact(ReprStream stream, double[] list) {
+		stream.print("[ ");
+		for (double o : list) {
+			new Num(o).repr(stream);
 			stream.print(" ");
 		}
 		stream.print("]");

--- a/src/aya/obj/list/ListAlgorithms.java
+++ b/src/aya/obj/list/ListAlgorithms.java
@@ -99,14 +99,16 @@ public class ListAlgorithms {
 			}
 		} else {
 			int ix = 0;
-			for (int i = list.length; i < n-list.length; i++) {
+			for (int i = 0; i < n-list.length; i++) {
 				out[ix]	= pad;
 				ix++;
 			}
 			// copy the rest
-			for (int i = 0; i < list.length-n; i++) {
-				out[ix] = pad;
+			int i = 0;
+			while (ix < out.length) {
+				out[ix] = list[i];
 				ix++;
+				i++;
 			}
 		}
 		return out;

--- a/src/aya/obj/list/ListAlgorithms.java
+++ b/src/aya/obj/list/ListAlgorithms.java
@@ -1,6 +1,7 @@
 package aya.obj.list;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 
 import aya.ReprStream;
@@ -51,6 +52,26 @@ public class ListAlgorithms {
 		return out;
 	}
 
+	public static double[] headNoDeepcopyPad(double[] list, int n, double pad) {
+		double[] out = new double[n];
+		if (n <= list.length) {
+			for (int i = 0; i < n; i++) {
+				out[i] = list[i];
+			}
+		} else {
+			int ix = 0;
+			for (int i = 0; i < list.length; i++) {
+				out[ix] = list[i];
+				ix++;
+			}
+			for (int i = list.length; i < n; i++) {
+				out[ix]	= pad;
+				ix++;
+			}
+		}
+		return out;
+	}
+
 
 
 	public static <T extends Obj> ArrayList<T> tailNoDeepcopyPad(ArrayList<T> list, int n, T pad) {
@@ -67,6 +88,31 @@ public class ListAlgorithms {
 		}	
 		return out;
 	}
+
+
+	public static double[] tailNoDeepcopyPad(double[] list, int n, double pad) {
+		double[] out = new double[n];
+		if (n <= list.length) {
+			int ix = 0;
+			for (int i = list.length-n; i < list.length; i++) {
+				out[ix] = list[i];
+				ix++;
+			}
+		} else {
+			int ix = 0;
+			for (int i = list.length; i < n-list.length; i++) {
+				out[ix]	= pad;
+				ix++;
+			}
+			// copy the rest
+			for (int i = 0; i < list.length-n; i++) {
+				out[ix] = pad;
+				ix++;
+			}
+		}
+		return out;
+	}
+
 
 	public static ArrayList<Obj> tailDeepcopyPad(ArrayList<Obj> list, int n, Obj pad) {
 		ArrayList<Obj> out = new ArrayList<Obj>(n);
@@ -142,6 +188,14 @@ public class ListAlgorithms {
 		int count = 0;
 		for (int i = 0; i < list.size(); i++) {
 			count += list.get(i).equiv(o) ? 1 : 0;
+		}
+		return count;
+	}
+
+	public static int count(double[] list, double o) {
+		int count = 0;
+		for (int i = 0; i < list.length; i++) {
+			count += list[i] == o ? 1 : 0;
 		}
 		return count;
 	}

--- a/src/aya/obj/list/ListImpl.java
+++ b/src/aya/obj/list/ListImpl.java
@@ -32,7 +32,7 @@ public abstract class ListImpl {
 	public abstract Obj tail();
 
 	/** Return a rotated copy of the list */
-	public abstract  rotate(int n);
+	public abstract ListImpl rotate(int n);
 	
 	/** Remove and return the head of the list */
 	public abstract Obj pop();

--- a/src/aya/obj/list/ListImpl.java
+++ b/src/aya/obj/list/ListImpl.java
@@ -32,7 +32,7 @@ public abstract class ListImpl {
 	public abstract Obj tail();
 
 	/** Return a rotated copy of the list */
-	public abstract ListImpl rotate(int n);
+	public abstract  rotate(int n);
 	
 	/** Remove and return the head of the list */
 	public abstract Obj pop();

--- a/src/aya/obj/list/ListImpl.java
+++ b/src/aya/obj/list/ListImpl.java
@@ -30,6 +30,9 @@ public abstract class ListImpl {
 	
 	/** Return the back of the list */
 	public abstract Obj tail();
+
+	/** Return a rotated copy of the list */
+	public abstract ListImpl rotate(int n);
 	
 	/** Remove and return the head of the list */
 	public abstract Obj pop();
@@ -39,9 +42,6 @@ public abstract class ListImpl {
 	
 	/** Reverse the list in place */
 	public abstract void reverse();
-
-	/** Rotate the list in place */
-	public abstract void rotate(int n);
 	
 	/** Sort the list */
 	public abstract void sort();

--- a/src/aya/obj/list/ListRangeUtils.java
+++ b/src/aya/obj/list/ListRangeUtils.java
@@ -5,27 +5,27 @@ import static aya.util.Casting.asList;
 import aya.exceptions.runtime.ValueError;
 import aya.obj.Obj;
 import aya.obj.character.Char;
-import aya.obj.list.numberlist.NumberItemList;
+import aya.obj.list.numberlist.NumberList;
 import aya.obj.number.Number;
 import aya.obj.number.NumberMath;
 
 public class ListRangeUtils {
 
-	public static NumberItemList buildRange(Number n) {
+	public static NumberList buildRange(Number n) {
 		if(n.compareTo(n.zero()) < 0) {
 			// :4 R => [-4 -3 -2 -1]
-			return new NumberItemList(n, n.negOne(), n.one());
+			return NumberList.range(n, n.negOne(), n.one());
 		} else {
 			// r R => [1 2 3 4]
-			return new NumberItemList(n.one(), n, n.one());
+			return NumberList.range(n.one(), n, n.one());
 		}
 	}
 
 	
-	public static NumberItemList buildRange(Number lo, Number hi) {
+	public static NumberList buildRange(Number lo, Number hi) {
 		Number inc = lo.one();
 		if(lo.compareTo(hi) > 0) inc = lo.negOne();
-		return new NumberItemList(lo, hi, inc);
+		return NumberList.range(lo, hi, inc);
 	}
 	
 	
@@ -114,7 +114,7 @@ public class ListRangeUtils {
 				Number lo = (Number)x;
 				Number hi = (Number)z;
 				Number inc = NumberMath.sub((Number)y, lo);
-				return new NumberItemList(lo, hi, inc);
+				return NumberList.range(lo, hi, inc);
 			} else if(x.isa(Obj.CHAR) || y.isa(Obj.CHAR) || z.isa(Obj.CHAR)) {
 				return new Str(charRange(((Char)x).charValue(), ((Char)z).charValue(), ((Char)y).charValue() - (((Char)x)).charValue()));
 			} else {

--- a/src/aya/obj/list/Str.java
+++ b/src/aya/obj/list/Str.java
@@ -165,7 +165,7 @@ public class Str extends ListImpl implements Comparable<Str> {
 	}
 
 	@Override
-	public void rotate(int n) {
+	public ListImpl rotate(int n) {
 		// TODO: implement
 		throw new RuntimeException("Str.rotate unimplemented");
 	}

--- a/src/aya/obj/list/Str.java
+++ b/src/aya/obj/list/Str.java
@@ -166,8 +166,22 @@ public class Str extends ListImpl implements Comparable<Str> {
 
 	@Override
 	public ListImpl rotate(int n) {
-		// TODO: implement
-		throw new RuntimeException("Str.rotate unimplemented");
+		if (n == 0) {
+			return new Str(_str);
+		} else {
+			final int len = _str.length();
+			char[] out = new char[len];
+			char[] ch_list = _str.toCharArray();
+			if (n > 0) {
+				System.arraycopy(ch_list, 0, out, n, len - n);
+				System.arraycopy(ch_list, len-n, out, 0, n);
+			} else {
+				n *= -1;
+				System.arraycopy(ch_list, 0, out, len-n, n);
+				System.arraycopy(ch_list, n, out, 0, len-n);
+			}
+			return new Str(out);
+		}
 	}
 
 	@Override

--- a/src/aya/obj/list/Str.java
+++ b/src/aya/obj/list/Str.java
@@ -11,7 +11,7 @@ import aya.ReprStream;
 import aya.exceptions.runtime.ValueError;
 import aya.obj.Obj;
 import aya.obj.character.Char;
-import aya.obj.list.numberlist.NumberItemList;
+import aya.obj.list.numberlist.NumberList;
 import aya.obj.number.Num;
 import aya.obj.number.Number;
 import aya.util.Casting;
@@ -221,7 +221,7 @@ public class Str extends ListImpl implements Comparable<Str> {
 		return found;
 	}
 	
-	public NumberItemList findAll(Obj o) {
+	public NumberList findAll(Obj o) {
 		ArrayList<Number> out = new ArrayList<Number>();
 		if (o instanceof Char) {
 			char c = Casting.asChar(o).charValue();
@@ -231,7 +231,7 @@ public class Str extends ListImpl implements Comparable<Str> {
 				}
 			}
 		} 
-		return new NumberItemList(out);
+		return NumberList.fromNumberAL(out);
 	}
 
 	@Override
@@ -297,13 +297,8 @@ public class Str extends ListImpl implements Comparable<Str> {
 	}
 
 	@Override
-	public NumberItemList toNumberList() {
-		char[] chars = _str.toCharArray();
-		ArrayList<Number> nums = new ArrayList<Number>(chars.length);
-		for (char c : chars) {
-			nums.add(new Num(c));
-		}
-		return new NumberItemList(nums);
+	public NumberList toNumberList() {
+		return NumberList.fromChars(_str.toCharArray());
 	}
 	
 	

--- a/src/aya/obj/list/Str.java
+++ b/src/aya/obj/list/Str.java
@@ -8,6 +8,7 @@ import java.util.TreeSet;
 import java.util.regex.Pattern;
 
 import aya.ReprStream;
+import aya.exceptions.runtime.AyaRuntimeException;
 import aya.exceptions.runtime.ValueError;
 import aya.obj.Obj;
 import aya.obj.character.Char;
@@ -166,6 +167,7 @@ public class Str extends ListImpl implements Comparable<Str> {
 	@Override
 	public void rotate(int n) {
 		// TODO: implement
+		throw new RuntimeException("Str.rotate unimplemented");
 	}
 
 	@Override

--- a/src/aya/obj/list/numberlist/DoubleList.java
+++ b/src/aya/obj/list/numberlist/DoubleList.java
@@ -160,7 +160,7 @@ public class DoubleList extends NumberList {
 			for (int i = 0; i < _list.length; i++) out[i] = _list[i] + N;
 			return new DoubleList(out);
 		} else {
-			return NumberItemList.fromDoubles(_list).add(n);
+			return toNumberItemList().add(n);
 		}
 	}
 
@@ -172,7 +172,7 @@ public class DoubleList extends NumberList {
 			for (int i = 0; i < _list.length; i++) out[i] = _list[i] - N;
 			return new DoubleList(out);
 		} else {
-			return NumberItemList.fromDoubles(_list).sub(n);
+			return toNumberItemList().sub(n);
 		}
 	}
 
@@ -184,7 +184,7 @@ public class DoubleList extends NumberList {
 			for (int i = 0; i < _list.length; i++) out[i] = _list[i] / N;
 			return new DoubleList(out);
 		} else {
-			return NumberItemList.fromDoubles(_list).div(n);
+			return toNumberItemList().div(n);
 		}
 	}
 
@@ -196,7 +196,7 @@ public class DoubleList extends NumberList {
 			for (int i = 0; i < _list.length; i++) out[i] = _list[i] * N;
 			return new DoubleList(out);
 		} else {
-			return NumberItemList.fromDoubles(_list).mul(n);
+			return toNumberItemList().mul(n);
 		}
 	}
 
@@ -208,7 +208,7 @@ public class DoubleList extends NumberList {
 			for (int i = 0; i < _list.length; i++) out[i] = _list[i] % N;
 			return new DoubleList(out);
 		} else {
-			return NumberItemList.fromDoubles(_list).mod(n);
+			return toNumberItemList().mod(n);
 		}
 	}
 	
@@ -220,7 +220,7 @@ public class DoubleList extends NumberList {
 			for (int i = 0; i < _list.length; i++) out[i] = Math.floor(_list[i] / N);
 			return new DoubleList(out);
 		} else {
-			return NumberItemList.fromDoubles(_list).idiv(n);
+			return toNumberItemList().idiv(n);
 		}
 	}
 
@@ -232,7 +232,7 @@ public class DoubleList extends NumberList {
 			for (int i = 0; i < _list.length; i++) out[i] = Math.pow(_list[i], N);
 			return new DoubleList(out);
 		} else {
-			return NumberItemList.fromDoubles(_list).pow(n);
+			return toNumberItemList().pow(n);
 		}
 	}
 
@@ -244,7 +244,7 @@ public class DoubleList extends NumberList {
 			for (int i = 0; i < _list.length; i++) out[i] = N - _list[i];
 			return new DoubleList(out);
 		} else {
-			return NumberItemList.fromDoubles(_list).subFrom(n);
+			return toNumberItemList().subFrom(n);
 		}
 	}
 
@@ -256,7 +256,7 @@ public class DoubleList extends NumberList {
 			for (int i = 0; i < _list.length; i++) out[i] = N / _list[i];
 			return new DoubleList(out);
 		} else {
-			return NumberItemList.fromDoubles(_list).divFrom(n);
+			return toNumberItemList().divFrom(n);
 		}
 	}
 
@@ -268,7 +268,7 @@ public class DoubleList extends NumberList {
 			for (int i = 0; i < _list.length; i++) out[i] = N % _list[i];
 			return new DoubleList(out);
 		} else {
-			return NumberItemList.fromDoubles(_list).modFrom(n);
+			return toNumberItemList().modFrom(n);
 		}
 	}
 
@@ -280,7 +280,7 @@ public class DoubleList extends NumberList {
 			for (int i = 0; i < _list.length; i++) out[i] = Math.floor(N / _list[i]);
 			return new DoubleList(out);
 		} else {
-			return NumberItemList.fromDoubles(_list).idivFrom(n);
+			return toNumberItemList().idivFrom(n);
 		}
 	}
 
@@ -292,7 +292,7 @@ public class DoubleList extends NumberList {
 			for (int i = 0; i < _list.length; i++) out[i] = Math.pow(N, _list[i]);
 			return new DoubleList(out);
 		} else {
-			return NumberItemList.fromDoubles(_list).powFrom(n);
+			return toNumberItemList().powFrom(n);
 		}
 	}
 
@@ -304,7 +304,7 @@ public class DoubleList extends NumberList {
 			for (int i = 0; i < _list.length; i++) out[i] = (double)((int)_list[i] & N);
 			return new DoubleList(out);
 		} else {
-			return NumberItemList.fromDoubles(_list).band(n);
+			return toNumberItemList().band(n).promote();
 		}
 	}
 
@@ -316,7 +316,7 @@ public class DoubleList extends NumberList {
 			for (int i = 0; i < _list.length; i++) out[i] = (double)(N & (int)_list[i]);
 			return new DoubleList(out);
 		} else {
-			return NumberItemList.fromDoubles(_list).bandFrom(n);
+			return toNumberItemList().bandFrom(n).promote();
 		}
 	}
 
@@ -328,7 +328,7 @@ public class DoubleList extends NumberList {
 			for (int i = 0; i < _list.length; i++) out[i] = (double)((int)_list[i] | N);
 			return new DoubleList(out);
 		} else {
-			return NumberItemList.fromDoubles(_list).bor(n);
+			return toNumberItemList().bor(n).promote();
 		}
 	}
 
@@ -340,7 +340,7 @@ public class DoubleList extends NumberList {
 			for (int i = 0; i < _list.length; i++) out[i] = (double)(N | (int)_list[i]);
 			return new DoubleList(out);
 		} else {
-			return NumberItemList.fromDoubles(_list).borFrom(n);
+			return toNumberItemList().borFrom(n).promote();
 		}
 	}
 	
@@ -468,7 +468,7 @@ public class DoubleList extends NumberList {
 
 	@Override
 	public NumberList imag() {
-		return NumberItemList.fromDoubles(_list).imag();
+		return toNumberItemList().imag();
 	}
 
 	@Override
@@ -786,7 +786,7 @@ public class DoubleList extends NumberList {
 			for (int i = 0; i < len; i++) out[i] = _list[i] + NS._list[i];
 			return new DoubleList(out);
 		} else {
-			return NumberItemList.fromDoubles(_list).add(ns);
+			return toNumberItemList().add(ns);
 		}
 	}
 
@@ -800,7 +800,7 @@ public class DoubleList extends NumberList {
 			for (int i = 0; i < len; i++) out[i] = _list[i] - NS._list[i];
 			return new DoubleList(out);
 		} else {
-			return NumberItemList.fromDoubles(_list).sub(ns);
+			return toNumberItemList().sub(ns);
 		}
 	}
 
@@ -814,7 +814,7 @@ public class DoubleList extends NumberList {
 			for (int i = 0; i < len; i++) out[i] = NS._list[i] - _list[i];
 			return new DoubleList(out);
 		} else {
-			return NumberItemList.fromDoubles(_list).subFrom(ns);
+			return toNumberItemList().subFrom(ns);
 		}
 	}
 
@@ -829,7 +829,7 @@ public class DoubleList extends NumberList {
 			for (int i = 0; i < len; i++) out[i] = _list[i] / NS._list[i];
 			return new DoubleList(out);
 		} else {
-			return NumberItemList.fromDoubles(_list).div(ns);
+			return toNumberItemList().div(ns);
 		}
 	}
 
@@ -843,7 +843,7 @@ public class DoubleList extends NumberList {
 			for (int i = 0; i < len; i++) out[i] = NS._list[i] / _list[i];
 			return new DoubleList(out);
 		} else {
-			return NumberItemList.fromDoubles(_list).divFrom(ns);
+			return toNumberItemList().divFrom(ns);
 		}
 	}
 
@@ -857,7 +857,7 @@ public class DoubleList extends NumberList {
 			for (int i = 0; i < len; i++) out[i] = _list[i] * NS._list[i];
 			return new DoubleList(out);
 		} else {
-			return NumberItemList.fromDoubles(_list).mul(ns);
+			return toNumberItemList().mul(ns);
 		}
 	}
 
@@ -871,7 +871,7 @@ public class DoubleList extends NumberList {
 			for (int i = 0; i < len; i++) out[i] = _list[i] % NS._list[i];
 			return new DoubleList(out);
 		} else {
-			return NumberItemList.fromDoubles(_list).mod(ns);
+			return toNumberItemList().mod(ns);
 		}
 	}
 
@@ -885,7 +885,7 @@ public class DoubleList extends NumberList {
 			for (int i = 0; i < len; i++) out[i] = NS._list[i] % _list[i];
 			return new DoubleList(out);
 		} else {
-			return NumberItemList.fromDoubles(_list).modFrom(ns);
+			return toNumberItemList().modFrom(ns);
 		}
 	}
 
@@ -899,7 +899,7 @@ public class DoubleList extends NumberList {
 			for (int i = 0; i < len; i++) out[i] = Math.floor(_list[i] / NS._list[i]);
 			return new DoubleList(out);
 		} else {
-			return NumberItemList.fromDoubles(_list).idiv(ns);
+			return toNumberItemList().idiv(ns);
 		}
 	}
 
@@ -913,7 +913,7 @@ public class DoubleList extends NumberList {
 			for (int i = 0; i < len; i++) out[i] = Math.floor(NS._list[i] / _list[i]);
 			return new DoubleList(out);
 		} else {
-			return NumberItemList.fromDoubles(_list).idivFrom(ns);
+			return toNumberItemList().idivFrom(ns);
 		}
 	}
 
@@ -927,7 +927,7 @@ public class DoubleList extends NumberList {
 			for (int i = 0; i < len; i++) out[i] = Math.pow(_list[i], NS._list[i]);
 			return new DoubleList(out);
 		} else {
-			return NumberItemList.fromDoubles(_list).pow(ns);
+			return toNumberItemList().pow(ns);
 		}
 	}
 
@@ -941,7 +941,7 @@ public class DoubleList extends NumberList {
 			for (int i = 0; i < len; i++) out[i] = Math.pow(NS._list[i], _list[i]);
 			return new DoubleList(out);
 		} else {
-			return NumberItemList.fromDoubles(_list).powFrom(ns);
+			return toNumberItemList().powFrom(ns);
 		}
 	}
 
@@ -955,7 +955,7 @@ public class DoubleList extends NumberList {
 			for (int i = 0; i < len; i++) out[i] = ((int)_list[i]) & ((int)NS._list[i]);
 			return new DoubleList(out);
 		} else {
-			return NumberItemList.fromDoubles(_list).band(ns);
+			return toNumberItemList().band(ns).promote();
 		}
 	}
 
@@ -969,7 +969,7 @@ public class DoubleList extends NumberList {
 			for (int i = 0; i < len; i++) out[i] = ((int)NS._list[i]) & ((int)_list[i]);
 			return new DoubleList(out);
 		} else {
-			return NumberItemList.fromDoubles(_list).bandFrom(ns);
+			return toNumberItemList().bandFrom(ns).promote();
 		}
 	}
 
@@ -983,7 +983,7 @@ public class DoubleList extends NumberList {
 			for (int i = 0; i < len; i++) out[i] = ((int)_list[i]) | ((int)NS._list[i]);
 			return new DoubleList(out);
 		} else {
-			return NumberItemList.fromDoubles(_list).bor(ns);
+			return toNumberItemList().bor(ns).promote();
 		}
 	}
 
@@ -997,7 +997,7 @@ public class DoubleList extends NumberList {
 			for (int i = 0; i < len; i++) out[i] = ((int)NS._list[i]) | ((int)_list[i]);
 			return new DoubleList(out);
 		} else {
-			return NumberItemList.fromDoubles(_list).borFrom(ns);
+			return toNumberItemList().borFrom(ns).promote();
 		}
 	}
 
@@ -1141,7 +1141,12 @@ public class DoubleList extends NumberList {
 	private NumberItemList toNumberItemList() {
 		ArrayList<Number> out = new ArrayList<Number>();
 		for (double d : _list) out.add(new Num(d));
-		return new NumberItemList(out);
+		return new NumberItemList(out, _list.length);
+	}
+
+	@Override
+	public DoubleList promote() {
+		return this;
 	}
 
 }

--- a/src/aya/obj/list/numberlist/DoubleList.java
+++ b/src/aya/obj/list/numberlist/DoubleList.java
@@ -551,7 +551,7 @@ public class DoubleList extends NumberList {
 	public DoubleList get(int[] is) {
 		double[] out = new double[is.length];
 		for (int i = 0; i < is.length; i++) {
-			out[i] = _list[i];
+			out[i] = _list[is[i]];
 		}
 		return new DoubleList(out);
 	}

--- a/src/aya/obj/list/numberlist/DoubleList.java
+++ b/src/aya/obj/list/numberlist/DoubleList.java
@@ -509,25 +509,32 @@ public class DoubleList extends NumberList {
 
 	@Override
 	public Number pop() {
-		NumberItemList ns = toNumberItemList();
-		Number n = ns.pop();
-		_list = ns.todoubleArray();
-		return n;
+		double n = _list[0];
+		_list = Arrays.copyOfRange(_list, 1, _list.length);
+		return new Num(n);
 	}
 
 	@Override
 	public Number popBack() {
-		NumberItemList ns = toNumberItemList();
-		Number n = ns.popBack();
-		_list = ns.todoubleArray();
-		return n;
+		double n = _list[_list.length-1];
+		_list = Arrays.copyOf(_list, _list.length-1);
+		return new Num(n);
 	}
 
 	@Override
 	public void reverse() {
-		NumberItemList ns = toNumberItemList();
-		ns.reverse();
-		_list = ns.todoubleArray();
+		final int len = _list.length;
+
+        if(len <= 1){
+            return;
+        }       
+        
+		double tmp;
+        for (int i = 0; i < len / 2; i++) {
+            tmp = _list[i];
+            _list[i] = _list[len - 1 - i];
+            _list[len - 1 - i] = tmp;
+        }
 	}
 
 	@Override
@@ -551,8 +558,7 @@ public class DoubleList extends NumberList {
 
 	@Override
 	public DoubleList slice(int i, int j) {
-		NumberItemList ns = toNumberItemList();
-		return new DoubleList(ns.slice(i, j).todoubleArray());
+		return new DoubleList(Arrays.copyOfRange(_list, i, j));
 	}
 
 	@Override
@@ -571,6 +577,7 @@ public class DoubleList extends NumberList {
 	
 	@Override
 	public Number remove(int i) {
+		// TODO: DoubleList implementation
 		NumberItemList ns = toNumberItemList();
 		Number n = ns.remove(i);
 		_list = ns.todoubleArray();
@@ -579,6 +586,7 @@ public class DoubleList extends NumberList {
 	
 	@Override
 	public void removeAll(int[] ixs) {
+		// TODO: DoubleList implementation
 		NumberItemList ns = toNumberItemList();
 		ns.removeAll(ixs);
 		_list = ns.todoubleArray();
@@ -586,16 +594,26 @@ public class DoubleList extends NumberList {
 
 	@Override
 	public int find(Obj o) {
-		return toNumberItemList().find(o);
+		if (o.isa(Obj.NUM)) {
+			double d = Casting.asNumber(o).toDouble();
+			for (int i = 0; i < _list.length; i++) {
+				if (d == _list[i]) {
+					return i;
+				}
+			}
+		}
+		return -(_list.length + 1);
 	}
 
 	@Override
 	public NumberList findAll(Obj o) {
+		// TODO: DoubleList implementation
 		return toNumberItemList().findAll(o);
 	}
 
 	@Override
 	public int findBack(Obj o) {
+		// TODO: DoubleList implementation
 		return toNumberItemList().findBack(o);
 	}
 
@@ -629,6 +647,7 @@ public class DoubleList extends NumberList {
 	
 	@Override
 	public DoubleList unique() {
+		// TODO: DoubleList implementation
 		return new DoubleList(toNumberItemList().unique().toNumberList().todoubleArray());
 	}
 	
@@ -648,16 +667,25 @@ public class DoubleList extends NumberList {
 	
 	@Override
 	public void addItem(int i, Obj o) {
-		NumberItemList ns = toNumberItemList();
-		ns.addItem(i, (Num)o);
-		_list = ns.todoubleArray();
+		double[] list = Arrays.copyOf(_list, _list.length + 1);
+		// Move everything after the index over one
+		for (int j = list.length-1; j > i; j--) {
+			list[j] = list[j-1];
+		}
+		list[i] = ((Num)o).toDouble();
+		_list = list;
 	}
 
 	@Override
 	public void addAll(ListImpl l) {
-		for (int i = 0; i < l.length(); i++) {
-			addItem(l.get(i));
-		}
+		double[] other = ((DoubleList)l)._list;
+		final int len = _list.length;
+		final int o_len = other.length;
+
+		double[] c = new double[len + o_len];
+		System.arraycopy(_list, 0, c, 0, len);
+		System.arraycopy(other, 0, c, len, o_len);
+		_list = c;
 	}
 	
 	@Override
@@ -689,6 +717,7 @@ public class DoubleList extends NumberList {
 	
 	@Override
 	public List split(Obj o) {
+		// TODO: DoubleList implementation
 		return toNumberItemList().split(o);
 	}
 	

--- a/src/aya/obj/list/numberlist/DoubleList.java
+++ b/src/aya/obj/list/numberlist/DoubleList.java
@@ -1,0 +1,1121 @@
+package aya.obj.list.numberlist;
+
+import static aya.util.Casting.asNumber;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+
+import aya.ReprStream;
+import aya.exceptions.runtime.ValueError;
+import aya.obj.Obj;
+import aya.obj.list.List;
+import aya.obj.list.ListAlgorithms;
+import aya.obj.list.ListImpl;
+import aya.obj.number.Num;
+import aya.obj.number.Number;
+import aya.obj.number.NumberMath;
+import aya.util.Casting;
+import aya.util.MathUtils;
+
+/** List containing a list of Number objects */
+public class DoubleList extends NumberList {
+	
+	double[] _list;
+	
+	public DoubleList(double[] list) {
+		_list = list;
+	}
+	
+	/** Create a new numeric list by repeating item, repeats times */
+	public DoubleList(double item, int repeats) {
+		_list = new double[repeats];
+		if (item != 0.0) {
+			for (int i = 0; i < repeats; i++) {
+				_list[i] = item;
+			}
+		}
+	}
+	
+	public DoubleList(double lo, double hi, double inc) {
+		//Calculate the number of items, this will return a negative value if array creation is impossible
+		int numOfItems = (int)Math.floor((hi - lo) / inc) + 1;
+	
+		if(numOfItems > 10000000) {
+			throw new ValueError("Cannot create range with more than 10^7 elements"); 
+		} else if (numOfItems < 0) {
+			throw new ValueError("Cannot create range containing a negative number of elements in"
+					+ " ["+ (new Num(lo)).repr() +" "+ (new Num(lo+inc)).repr() +" "+ (new Num(hi)).repr() +"]" );
+		}
+		
+		_list = new double[numOfItems];
+		
+		//Increment up or down?
+		if ( (lo > hi && inc > 0) || ((lo < hi) && inc < 0) ) {
+			for(int i = 0; i < numOfItems; i++, lo -= inc) {
+				_list[i] = lo;
+			}
+		} else {
+			for(int i = 0; i < numOfItems; i++, lo += inc) {
+				_list[i] = lo;
+			}
+		}
+	}
+	
+	
+	//////////////
+	// Creation //
+	//////////////
+
+	public static DoubleList fromBytes(byte[] bytes) {
+		double[] out = new double[bytes.length];
+		for (int i = 0; i < bytes.length; i++) {
+			out[i] = (double)bytes[i];
+		}
+		return new DoubleList(out);
+	}
+
+	//////////////////////////
+	// NUMBERLIST OVERRIDES //
+	//////////////////////////
+	
+	@Override
+	public Number max() {
+		double max = Num.MIN_VALUE.toDouble();
+		for (int i = 0; i < _list.length; i++) {
+			if (!Double.isNaN(_list[i]) && _list[i] > max) {
+				max = _list[i];
+			}
+		}
+		return new Num(max);
+	}
+
+	@Override
+	public Number min() {
+		double min = Num.MAX_VALUE.toDouble();
+		for (int i = 0; i < _list.length; i++) {
+			if (!Double.isNaN(_list[i]) && _list[i] < min) {
+				min = _list[i];
+			}
+		}
+		return new Num(min);
+	}
+
+	@Override
+	public Number mean() {
+		return _list.length == 0 ? Num.ZERO : new Num(sum().toDouble() / (double)_list.length);
+	}
+
+	@Override
+	public Number sum() {
+		double total = 0;
+		for (int i = 0; i < _list.length; i++) {
+			total += _list[i];
+		}
+		return new Num(total);
+	}
+	
+	@Override
+	public Integer[] toIntegerArray() {
+		Integer[] ints = new Integer[_list.length];
+		for (int i = 0; i < _list.length; i++) {
+			ints[i] = (int)_list[i];
+		}
+		return ints;
+	}
+			
+	@Override
+	public int[] toIntArray() {
+		int[] ints = new int[_list.length];
+		for (int i = 0; i < _list.length; i++) {
+			ints[i] = (int)_list[i];
+		}
+		return ints;
+	}
+	
+	@Override
+	public double[] todoubleArray() {
+		double[] out = new double[_list.length];
+		for (int i = 0; i < _list.length; i++) {
+			out[i] = _list[i];
+		}
+		return out;
+	}
+	
+	@Override
+	public byte[] toByteArray() {
+		byte[] bs = new byte[_list.length];
+		for (int i = 0; i < _list.length; i++) {
+			bs[i] = (byte)_list[i];
+		}
+		return bs;
+	}
+
+	
+	@Override
+	public NumberList add(Number n) {
+		if (n.isa(Obj.NUM)) {
+			double N = n.toDouble();
+			double[] out = new double[_list.length];
+			for (int i = 0; i < _list.length; i++) out[i] = _list[i] + N;
+			return new DoubleList(out);
+		} else {
+			return NumberItemList.fromDoubles(_list).add(n);
+		}
+	}
+
+	@Override
+	public NumberList sub(Number n) {
+		if (n.isa(Obj.NUM)) {
+			double N = n.toDouble();
+			double[] out = new double[_list.length];
+			for (int i = 0; i < _list.length; i++) out[i] = _list[i] - N;
+			return new DoubleList(out);
+		} else {
+			return NumberItemList.fromDoubles(_list).sub(n);
+		}
+	}
+
+	@Override
+	public NumberList div(Number n) {
+		if (n.isa(Obj.NUM)) {
+			double N = n.toDouble();
+			double[] out = new double[_list.length];
+			for (int i = 0; i < _list.length; i++) out[i] = _list[i] / N;
+			return new DoubleList(out);
+		} else {
+			return NumberItemList.fromDoubles(_list).div(n);
+		}
+	}
+
+	@Override
+	public NumberList mul(Number n) {
+		if (n.isa(Obj.NUM)) {
+			double N = n.toDouble();
+			double[] out = new double[_list.length];
+			for (int i = 0; i < _list.length; i++) out[i] = _list[i] * N;
+			return new DoubleList(out);
+		} else {
+			return NumberItemList.fromDoubles(_list).mul(n);
+		}
+	}
+
+	@Override
+	public NumberList mod(Number n) {
+		if (n.isa(Obj.NUM)) {
+			double N = n.toDouble();
+			double[] out = new double[_list.length];
+			for (int i = 0; i < _list.length; i++) out[i] = _list[i] % N;
+			return new DoubleList(out);
+		} else {
+			return NumberItemList.fromDoubles(_list).mod(n);
+		}
+	}
+	
+	@Override
+	public NumberList idiv(Number n) {
+		if (n.isa(Obj.NUM)) {
+			double N = n.toDouble();
+			double[] out = new double[_list.length];
+			for (int i = 0; i < _list.length; i++) out[i] = Math.floor(_list[i] / N);
+			return new DoubleList(out);
+		} else {
+			return NumberItemList.fromDoubles(_list).idiv(n);
+		}
+	}
+
+	@Override
+	public NumberList pow(Number n) {
+		if (n.isa(Obj.NUM)) {
+			double N = n.toDouble();
+			double[] out = new double[_list.length];
+			for (int i = 0; i < _list.length; i++) out[i] = Math.pow(_list[i], N);
+			return new DoubleList(out);
+		} else {
+			return NumberItemList.fromDoubles(_list).pow(n);
+		}
+	}
+
+	@Override
+	public NumberList subFrom(Number n) {
+		if (n.isa(Obj.NUM)) {
+			double N = n.toDouble();
+			double[] out = new double[_list.length];
+			for (int i = 0; i < _list.length; i++) out[i] = N - _list[i];
+			return new DoubleList(out);
+		} else {
+			return NumberItemList.fromDoubles(_list).subFrom(n);
+		}
+	}
+
+	@Override
+	public NumberList divFrom(Number n) {
+		if (n.isa(Obj.NUM)) {
+			double N = n.toDouble();
+			double[] out = new double[_list.length];
+			for (int i = 0; i < _list.length; i++) out[i] = N / _list[i];
+			return new DoubleList(out);
+		} else {
+			return NumberItemList.fromDoubles(_list).divFrom(n);
+		}
+	}
+
+	@Override
+	public NumberList modFrom(Number n) {
+		if (n.isa(Obj.NUM)) {
+			double N = n.toDouble();
+			double[] out = new double[_list.length];
+			for (int i = 0; i < _list.length; i++) out[i] = N % _list[i];
+			return new DoubleList(out);
+		} else {
+			return NumberItemList.fromDoubles(_list).modFrom(n);
+		}
+	}
+
+	@Override
+	public NumberList idivFrom(Number n) {
+		if (n.isa(Obj.NUM)) {
+			double N = n.toDouble();
+			double[] out = new double[_list.length];
+			for (int i = 0; i < _list.length; i++) out[i] = Math.floor(N / _list[i]);
+			return new DoubleList(out);
+		} else {
+			return NumberItemList.fromDoubles(_list).idivFrom(n);
+		}
+	}
+
+	@Override
+	public NumberList powFrom(Number n) {
+		if (n.isa(Obj.NUM)) {
+			double N = n.toDouble();
+			double[] out = new double[_list.length];
+			for (int i = 0; i < _list.length; i++) out[i] = Math.pow(N, _list[i]);
+			return new DoubleList(out);
+		} else {
+			return NumberItemList.fromDoubles(_list).powFrom(n);
+		}
+	}
+
+	@Override
+	public NumberList band(Number n) {
+		if (n.isa(Obj.NUM)) {
+			int N = n.toInt();
+			double[] out = new double[_list.length];
+			for (int i = 0; i < _list.length; i++) out[i] = (double)((int)_list[i] & N);
+			return new DoubleList(out);
+		} else {
+			return NumberItemList.fromDoubles(_list).band(n);
+		}
+	}
+
+	@Override
+	public NumberList bandFrom(Number n) {
+		if (n.isa(Obj.NUM)) {
+			int N = n.toInt();
+			double[] out = new double[_list.length];
+			for (int i = 0; i < _list.length; i++) out[i] = (double)(N & (int)_list[i]);
+			return new DoubleList(out);
+		} else {
+			return NumberItemList.fromDoubles(_list).bandFrom(n);
+		}
+	}
+
+	@Override
+	public NumberList bor(Number n) {
+		if (n.isa(Obj.NUM)) {
+			int N = n.toInt();
+			double[] out = new double[_list.length];
+			for (int i = 0; i < _list.length; i++) out[i] = (double)((int)_list[i] | N);
+			return new DoubleList(out);
+		} else {
+			return NumberItemList.fromDoubles(_list).bor(n);
+		}
+	}
+
+	@Override
+	public NumberList borFrom(Number n) {
+		if (n.isa(Obj.NUM)) {
+			int N = n.toInt();
+			double[] out = new double[_list.length];
+			for (int i = 0; i < _list.length; i++) out[i] = (double)(N | (int)_list[i]);
+			return new DoubleList(out);
+		} else {
+			return NumberItemList.fromDoubles(_list).borFrom(n);
+		}
+	}
+	
+	
+
+	
+	@Override
+	public NumberList negate() {
+		double[] out = new double[_list.length];
+		for (int i = 0; i < _list.length; i++) out[i] = _list[i] * -1;
+		return new DoubleList(out);
+	}
+
+	@Override
+	public NumberList bnot() {
+		double[] out = new double[_list.length];
+		for (int i = 0; i < _list.length; i++) out[i] = ~((int)_list[i]);
+		return new DoubleList(out);
+	}
+
+	@Override
+	public NumberList signnum() {
+		double[] out = new double[_list.length];
+		for (int i = 0; i < _list.length; i++) out[i] = MathUtils.signnum(_list[i]);
+		return new DoubleList(out);
+	}
+
+	@Override
+	public NumberList factorial() {
+		double[] out = new double[_list.length];
+		for (int i = 0; i < _list.length; i++) out[i] = MathUtils.factorial((long)_list[i]);
+		return new DoubleList(out);
+	}
+
+	@Override
+	public NumberList abs() {
+		double[] out = new double[_list.length];
+		for (int i = 0; i < _list.length; i++) out[i] = Math.abs(_list[i]);
+		return new DoubleList(out);
+	}
+	
+	@Override
+	public NumberList exp() {
+		double[] out = new double[_list.length];
+		for (int i = 0; i < _list.length; i++) out[i] = Math.exp(_list[i]);
+		return new DoubleList(out);
+	}
+
+	@Override
+	public NumberList sin() {	
+		double[] out = new double[_list.length];
+		for (int i = 0; i < _list.length; i++) out[i] = Math.sin(_list[i]);
+		return new DoubleList(out);
+	}
+
+	@Override
+	public NumberList cos() {
+		double[] out = new double[_list.length];
+		for (int i = 0; i < _list.length; i++) out[i] = Math.cos(_list[i]);
+		return new DoubleList(out);
+	}
+
+	@Override
+	public NumberList tan() {
+		double[] out = new double[_list.length];
+		for (int i = 0; i < _list.length; i++) out[i] = Math.tan(_list[i]);
+		return new DoubleList(out);
+	}
+
+	@Override
+	public NumberList asin() {
+		double[] out = new double[_list.length];
+		for (int i = 0; i < _list.length; i++) out[i] = Math.asin(_list[i]);
+		return new DoubleList(out);
+	}
+
+	@Override
+	public NumberList acos() {
+		double[] out = new double[_list.length];
+		for (int i = 0; i < _list.length; i++) out[i] = Math.acos(_list[i]);
+		return new DoubleList(out);
+	}
+
+	@Override
+	public NumberList atan() {
+		double[] out = new double[_list.length];
+		for (int i = 0; i < _list.length; i++) out[i] = Math.atan(_list[i]);
+		return new DoubleList(out);
+	}
+
+	@Override
+	public NumberList log() {
+		double[] out = new double[_list.length];
+		for (int i = 0; i < _list.length; i++) out[i] = Math.log10(_list[i]);
+		return new DoubleList(out);
+	}
+
+	@Override
+	public NumberList ln() {
+		double[] out = new double[_list.length];
+		for (int i = 0; i < _list.length; i++) out[i] = Math.log(_list[i]);
+		return new DoubleList(out);
+	}
+
+	@Override
+	public NumberList sqrt() {
+		double[] out = new double[_list.length];
+		for (int i = 0; i < _list.length; i++) out[i] = Math.sqrt(_list[i]);
+		return new DoubleList(out);
+	}
+
+	@Override
+	public NumberList ceil() {
+		double[] out = new double[_list.length];
+		for (int i = 0; i < _list.length; i++) out[i] = Math.ceil(_list[i]);
+		return new DoubleList(out);
+	}
+
+	@Override
+	public NumberList floor() {
+		double[] out = new double[_list.length];
+		for (int i = 0; i < _list.length; i++) out[i] = Math.floor(_list[i]);
+		return new DoubleList(out);
+	}
+
+	@Override
+	public NumberList imag() {
+		return NumberItemList.fromDoubles(_list).imag();
+	}
+
+	@Override
+	public ArrayList<Number> toArrayList() {
+		ArrayList<Number> out = new ArrayList<Number>(_list.length);
+		for (int i = 0; i < _list.length; i++) {
+			out.add(new Num(_list[i]));
+		}
+		return out;
+	}
+	
+	////////////////////
+	// LIST OVERRIDES //
+	////////////////////
+
+	@Override
+	public int length() {
+		return _list.length;
+	}
+
+	@Override
+	public DoubleList head(int n) {
+		return new DoubleList(ListAlgorithms.headNoDeepcopyPad(_list, n, Num.ZERO));
+	}
+
+	@Override
+	public DoubleList tail(int n) {
+		return new DoubleList(ListAlgorithms.tailNoDeepcopyPad(_list, n, Num.ZERO));
+	}
+
+	@Override
+	public Obj head() {
+		return new Num(_list[0]);
+	}
+
+	@Override
+	public Obj tail() {
+		return new Num(_list[_list.length-1]);
+	}
+
+	@Override
+	public Number pop() {
+		return _list.remove(0);
+	}
+
+	@Override
+	public Number popBack() {
+		return _list.remove(_list.length-1);
+	}
+
+	@Override
+	public void reverse() {
+		Collections.reverse(_list);
+	}
+
+	@Override
+	public void rotate(int n) {
+		ListAlgorithms.rotate(_list, n);
+	}
+
+	@Override
+	public DoubleList slice(int i, int j) {
+		return new DoubleList(ListAlgorithms.slice(_list, i, j));
+	}
+
+	@Override
+	public Number get(int i) {
+		return _list[i];
+	}
+	
+	@Override
+	public DoubleList get(int[] is) {
+		ArrayList<Number> out = new ArrayList<Number>(is.length);
+		for (int i : is) {
+			out.add(_list[i]);
+		}
+		return new DoubleList(out);
+	}
+	
+	@Override
+	public Number remove(int i) {
+		return _list.remove(i);
+	}
+	
+	@Override
+	public void removeAll(int[] ixs) {
+		ListAlgorithms.removeAll(_list, ixs);
+	}
+
+	@Override
+	public int find(Obj o) {
+		return ListAlgorithms.find(_list, o);
+	}
+
+	@Override
+	public DoubleList findAll(Obj o) {
+		return new DoubleList(ListAlgorithms.findAll(_list, o));
+	}
+
+	@Override
+	public int findBack(Obj o) {
+		return ListAlgorithms.findBack(_list, o);
+	}
+
+	@Override
+	public int count(Obj o) {
+		return ListAlgorithms.count(_list, o);
+	}
+	
+	@Override
+	public void sort() {
+		Collections.sort(_list);
+	}
+	
+	@Override
+	public void set(int i, Obj o) {
+		_list[i] = asNumber(o).toDouble();
+	}
+	
+	@Override
+	public ArrayList<Obj> getObjAL() {
+		ArrayList<Obj> l = new ArrayList<Obj>(_list.length);
+		for (int i = 0; i < _list.length; i++) {
+			l.add(new Num(_list[i]));
+		}
+		return l;
+	}
+	
+	@Override
+	public DoubleList unique() {
+		return new DoubleList(ListAlgorithms.unique(_list));
+	}
+	
+	
+	@Override
+	public DoubleList toNumberList() {
+		return this;
+	}
+
+
+	@Override
+	public void addItem(Obj o) {
+		_list.add((Number)o);
+	}
+	
+	@Override
+	public void addItem(int i, Obj o) {
+		_list.add(i, (Number)o);
+	}
+
+	@Override
+	public void addAll(ListImpl l) {
+		for (int i = 0; i < l.length(); i++) {
+			addItem(l.get(i));
+		}
+	}
+	
+	@Override
+	public DoubleList copy() {
+		double[] out = new double[_list.length];
+		for (int i = 0; i < _list.length; i++) out[i] = _list[i];
+		return new DoubleList(out);
+	}
+	
+	@Override
+	public boolean canInsert(Obj o) {
+		return o.isa(Obj.NUM);
+	}
+
+	@Override
+	public DoubleList similarEmpty() {
+		return new DoubleList(new double[0]);
+	}
+
+	@Override
+	public List sameShapeNull() {
+		return new List(new DoubleList(0, length()));
+	}
+
+	@Override
+	protected ListImpl flatten() {
+		return copy();
+	}
+	
+	@Override
+	public List split(Obj o) {
+		if (o.isa(Obj.NUMBER)) {
+			return List.from2DTemplate(ListAlgorithms.split(this._list, Casting.asNumber(o)));
+		} else {
+			return new List();
+		}
+	}
+	
+	
+	
+	///////////////////
+	// OBJ OVERRIDES //
+	///////////////////
+	
+	@Override
+	public DoubleList deepcopy() {
+		return copy();
+	}
+
+	@Override
+	public boolean bool() {
+		return _list.length != 0;
+	}
+
+	@Override
+	public ReprStream repr(ReprStream stream) {
+		return ListAlgorithms.reprCompact(stream, _list);
+	}
+
+	@Override
+	public String str() {
+		return ListAlgorithms.str(_list);
+	}
+
+	@Override
+	public boolean equiv(ListImpl list) {
+		// Must have the same length
+		if (list.length() == this.length()) {
+			// Every corresponding item must be equivalent
+			for (int i = 0; i < this.length(); i++) {
+				if (!list.get(i).equiv(new Num(_list[i]))) {
+					return false;
+				}
+			}
+			return true;
+		} else { 
+			return false;
+		}
+	}
+	
+	@Override
+	public boolean isa(byte type) {
+		return type == Obj.LIST || type == Obj.NUMBERLIST || type == Obj.DOUBLELIST;
+	}
+
+	@Override
+	public byte type() {
+		return Obj.DOUBLELIST;
+	}
+
+	//////////////////////
+	// HELPER FUNCTIONS //
+	//////////////////////
+	
+	/** Primes up to n **/
+	public static DoubleList primes(int n) {
+		boolean[] flags = new boolean[n];
+		Arrays.fill(flags, true);
+		
+		//Mark every space that is not prime
+		for (int i = 2; i <= n; i++) {
+			int z = 2*i;
+			while (z <= n) {
+				flags[z-1] = false; //zero index, so sub 1
+				z += i;
+			}
+		}
+		
+		//Allocate new array
+		ArrayList<Number> primeList = new ArrayList<Number>();
+		
+		//Add primes into array
+		for (int i = 2; i <= n; i++) {
+			if (flags[i-1]) {
+				primeList.add(Num.fromInt(i));
+			}
+		}
+
+		double[] out = new double[primeList.size()];
+		for (int i = 0; i < out.length; i++) out[i] = primeList.get(i).toDouble();
+		return new DoubleList(out);
+	}
+
+
+
+
+	private void boundsCheck(NumberList a, NumberList b) {
+		if (a.length() != b.length())
+			throw new ValueError("List length mismatch\n"
+					+ "  " + a.str() + "\n  " + b.str());
+	}
+	
+	@Override
+	public NumberList add(NumberList ns) {
+		boundsCheck(this, ns);
+		final int len = _list.length;
+		if (ns instanceof DoubleList) {
+			final DoubleList NS = (DoubleList)ns;
+			double[] out = new double[len];
+			for (int i = 0; i < len; i++) out[i] = _list[i] + NS._list[i];
+			return new DoubleList(out);
+		} else {
+			return NumberItemList.fromDoubles(_list).add(ns);
+		}
+	}
+
+	@Override
+	public NumberList sub(NumberList ns) {
+		boundsCheck(this, ns);
+		final int len = _list.length;
+		if (ns instanceof DoubleList) {
+			final DoubleList NS = (DoubleList)ns;
+			double[] out = new double[len];
+			for (int i = 0; i < len; i++) out[i] = _list[i] - NS._list[i];
+			return new DoubleList(out);
+		} else {
+			return NumberItemList.fromDoubles(_list).sub(ns);
+		}
+	}
+
+	@Override
+	public NumberList subFrom(NumberList ns) {
+		boundsCheck(this, ns);
+		final int len = _list.length;
+		if (ns instanceof DoubleList) {
+			final DoubleList NS = (DoubleList)ns;
+			double[] out = new double[len];
+			for (int i = 0; i < len; i++) out[i] = NS._list[i] - _list[i];
+			return new DoubleList(out);
+		} else {
+			return NumberItemList.fromDoubles(_list).subFrom(ns);
+		}
+	}
+
+
+	@Override
+	public NumberList div(NumberList ns) {
+		boundsCheck(this, ns);
+		final int len = _list.length;
+		if (ns instanceof DoubleList) {
+			final DoubleList NS = (DoubleList)ns;
+			double[] out = new double[len];
+			for (int i = 0; i < len; i++) out[i] = _list[i] / NS._list[i];
+			return new DoubleList(out);
+		} else {
+			return NumberItemList.fromDoubles(_list).div(ns);
+		}
+	}
+
+	@Override
+	public NumberList divFrom(NumberList ns) {
+		boundsCheck(this, ns);
+		final int len = _list.length;
+		if (ns instanceof DoubleList) {
+			final DoubleList NS = (DoubleList)ns;
+			double[] out = new double[len];
+			for (int i = 0; i < len; i++) out[i] = NS._list[i] / _list[i];
+			return new DoubleList(out);
+		} else {
+			return NumberItemList.fromDoubles(_list).divFrom(ns);
+		}
+	}
+
+	@Override
+	public NumberList mul(NumberList ns) {
+		boundsCheck(this, ns);
+		final int len = _list.length;
+		if (ns instanceof DoubleList) {
+			final DoubleList NS = (DoubleList)ns;
+			double[] out = new double[len];
+			for (int i = 0; i < len; i++) out[i] = _list[i] * NS._list[i];
+			return new DoubleList(out);
+		} else {
+			return NumberItemList.fromDoubles(_list).mul(ns);
+		}
+	}
+
+	@Override
+	public NumberList mod(NumberList ns) {
+		boundsCheck(this, ns);
+		final int len = _list.length;
+		if (ns instanceof DoubleList) {
+			final DoubleList NS = (DoubleList)ns;
+			double[] out = new double[len];
+			for (int i = 0; i < len; i++) out[i] = _list[i] % NS._list[i];
+			return new DoubleList(out);
+		} else {
+			return NumberItemList.fromDoubles(_list).mod(ns);
+		}
+	}
+
+	@Override
+	public NumberList modFrom(NumberList ns) {
+		boundsCheck(this, ns);
+		final int len = _list.length;
+		if (ns instanceof DoubleList) {
+			final DoubleList NS = (DoubleList)ns;
+			double[] out = new double[len];
+			for (int i = 0; i < len; i++) out[i] = NS._list[i] % _list[i];
+			return new DoubleList(out);
+		} else {
+			return NumberItemList.fromDoubles(_list).modFrom(ns);
+		}
+	}
+
+	@Override
+	public NumberList idiv(NumberList ns) {
+		boundsCheck(this, ns);
+		final int len = _list.length;
+		if (ns instanceof DoubleList) {
+			final DoubleList NS = (DoubleList)ns;
+			double[] out = new double[len];
+			for (int i = 0; i < len; i++) out[i] = Math.floor(_list[i] / NS._list[i]);
+			return new DoubleList(out);
+		} else {
+			return NumberItemList.fromDoubles(_list).idiv(ns);
+		}
+	}
+
+	@Override
+	public NumberList idivFrom(NumberList ns) {
+		boundsCheck(this, ns);
+		final int len = _list.length;
+		if (ns instanceof DoubleList) {
+			final DoubleList NS = (DoubleList)ns;
+			double[] out = new double[len];
+			for (int i = 0; i < len; i++) out[i] = Math.floor(NS._list[i] / _list[i]);
+			return new DoubleList(out);
+		} else {
+			return NumberItemList.fromDoubles(_list).idivFrom(ns);
+		}
+	}
+
+	@Override
+	public NumberList pow(NumberList ns) {
+		boundsCheck(this, ns);
+		final int len = _list.length;
+		if (ns instanceof DoubleList) {
+			final DoubleList NS = (DoubleList)ns;
+			double[] out = new double[len];
+			for (int i = 0; i < len; i++) out[i] = Math.pow(_list[i], NS._list[i]);
+			return new DoubleList(out);
+		} else {
+			return NumberItemList.fromDoubles(_list).pow(ns);
+		}
+	}
+
+	@Override
+	public NumberList powFrom(NumberList ns) {
+		boundsCheck(this, ns);
+		final int len = _list.length;
+		if (ns instanceof DoubleList) {
+			final DoubleList NS = (DoubleList)ns;
+			double[] out = new double[len];
+			for (int i = 0; i < len; i++) out[i] = Math.pow(NS._list[i], _list[i]);
+			return new DoubleList(out);
+		} else {
+			return NumberItemList.fromDoubles(_list).powFrom(ns);
+		}
+	}
+
+	@Override
+	public NumberList band(NumberList ns) {
+		boundsCheck(this, ns);
+		final int len = _list.length;
+		if (ns instanceof DoubleList) {
+			final DoubleList NS = (DoubleList)ns;
+			double[] out = new double[len];
+			for (int i = 0; i < len; i++) out[i] = ((int)_list[i]) & ((int)NS._list[i]);
+			return new DoubleList(out);
+		} else {
+			return NumberItemList.fromDoubles(_list).band(ns);
+		}
+	}
+
+	@Override
+	public NumberList bandFrom(NumberList ns) {
+		boundsCheck(this, ns);
+		final int len = _list.length;
+		if (ns instanceof DoubleList) {
+			final DoubleList NS = (DoubleList)ns;
+			double[] out = new double[len];
+			for (int i = 0; i < len; i++) out[i] = ((int)NS._list[i]) & ((int)_list[i]);
+			return new DoubleList(out);
+		} else {
+			return NumberItemList.fromDoubles(_list).bandFrom(ns);
+		}
+	}
+
+	@Override
+	public NumberList bor(NumberList ns) {
+		boundsCheck(this, ns);
+		final int len = _list.length;
+		if (ns instanceof DoubleList) {
+			final DoubleList NS = (DoubleList)ns;
+			double[] out = new double[len];
+			for (int i = 0; i < len; i++) out[i] = ((int)_list[i]) | ((int)NS._list[i]);
+			return new DoubleList(out);
+		} else {
+			return NumberItemList.fromDoubles(_list).bor(ns);
+		}
+	}
+
+	@Override
+	public NumberList borFrom(NumberList ns) {
+		boundsCheck(this, ns);
+		final int len = _list.length;
+		if (ns instanceof DoubleList) {
+			final DoubleList NS = (DoubleList)ns;
+			double[] out = new double[len];
+			for (int i = 0; i < len; i++) out[i] = ((int)NS._list[i]) | ((int)_list[i]);
+			return new DoubleList(out);
+		} else {
+			return NumberItemList.fromDoubles(_list).borFrom(ns);
+		}
+	}
+
+	
+	
+	@Override
+	public NumberList lt(Number n) {
+		final int len = _list.length;
+		double[] out = new double[len];
+		if (n.isa(Obj.NUM)) {
+			final double N = n.toDouble();
+			for (int i = 0; i < len; i++) out[i] = _list[i] < N ? 1 : 0;
+		} else {
+			for (int i = 0; i < len; i++) out[i] = new Num(_list[i]).compareTo(n) < 0 ? 1 : 0;
+		}
+		return new DoubleList(out);
+	}
+
+	@Override
+	public NumberList lt(NumberList ns) {
+		boundsCheck(this, ns);
+		int len = _list.length;
+		double[] out = new double[len];
+		if (ns instanceof DoubleList) {
+			final DoubleList NS = (DoubleList)ns;
+			for (int i = 0; i < len; i++) out[i] = _list[i] < NS._list[i] ? 1 : 0;
+		} else  {
+			for (int i = 0; i < len; i++) out[i] = new Num(_list[i]).compareTo(ns.get(i)) < 0 ? 1 : 0;
+		}
+		return new DoubleList(out);
+	}
+
+	@Override
+	public NumberList leq(Number n) {
+		final int len = _list.length;
+		double[] out = new double[len];
+		if (n.isa(Obj.NUM)) {
+			final double N = n.toDouble();
+			for (int i = 0; i < len; i++) out[i] = _list[i] <= N ? 1 : 0;
+		} else {
+			for (int i = 0; i < len; i++) out[i] = new Num(_list[i]).compareTo(n) <= 0 ? 1 : 0;
+		}
+		return new DoubleList(out);
+	}
+
+	@Override
+	public NumberList leq(NumberList ns) {
+		boundsCheck(this, ns);
+		int len = _list.length;
+		double[] out = new double[len];
+		if (ns instanceof DoubleList) {
+			final DoubleList NS = (DoubleList)ns;
+			for (int i = 0; i < len; i++) out[i] = _list[i] <= NS._list[i] ? 1 : 0;
+		} else  {
+			for (int i = 0; i < len; i++) out[i] = new Num(_list[i]).compareTo(ns.get(i)) <= 0 ? 1 : 0;
+		}
+		return new DoubleList(out);
+	}
+
+	@Override
+	public NumberList gt(Number n) {
+		final int len = _list.length;
+		double[] out = new double[len];
+		if (n.isa(Obj.NUM)) {
+			final double N = n.toDouble();
+			for (int i = 0; i < len; i++) out[i] = _list[i] > N ? 1 : 0;
+		} else {
+			for (int i = 0; i < len; i++) out[i] = new Num(_list[i]).compareTo(n) > 0 ? 1 : 0;
+		}
+		return new DoubleList(out);
+	}
+
+	@Override
+	public NumberList gt(NumberList ns) {
+		boundsCheck(this, ns);
+		int len = _list.length;
+		double[] out = new double[len];
+		if (ns instanceof DoubleList) {
+			final DoubleList NS = (DoubleList)ns;
+			for (int i = 0; i < len; i++) out[i] = _list[i] > NS._list[i] ? 1 : 0;
+		} else  {
+			for (int i = 0; i < len; i++) out[i] = new Num(_list[i]).compareTo(ns.get(i)) > 0 ? 1 : 0;
+		}
+		return new DoubleList(out);
+	}
+
+	@Override
+	public NumberList geq(Number n) {
+		final int len = _list.length;
+		double[] out = new double[len];
+		if (n.isa(Obj.NUM)) {
+			final double N = n.toDouble();
+			for (int i = 0; i < len; i++) out[i] = _list[i] >= N ? 1 : 0;
+		} else {
+			for (int i = 0; i < len; i++) out[i] = new Num(_list[i]).compareTo(n) >= 0 ? 1 : 0;
+		}
+		return new DoubleList(out);
+	}
+
+	@Override
+	public NumberList geq(NumberList ns) {
+		boundsCheck(this, ns);
+		int len = _list.length;
+		double[] out = new double[len];
+		if (ns instanceof DoubleList) {
+			final DoubleList NS = (DoubleList)ns;
+			for (int i = 0; i < len; i++) out[i] = _list[i] >= NS._list[i] ? 1 : 0;
+		} else  {
+			for (int i = 0; i < len; i++) out[i] = new Num(_list[i]).compareTo(ns.get(i)) >= 0 ? 1 : 0;
+		}
+		return new DoubleList(out);
+	}
+
+	@Override
+	public NumberList eq(Number n) {
+		final int len = _list.length;
+		double[] out = new double[len];
+		if (n.isa(Obj.NUM)) {
+			final double N = n.toDouble();
+			for (int i = 0; i < len; i++) out[i] = _list[i] == N ? 1 : 0;
+		} else {
+			for (int i = 0; i < len; i++) out[i] = new Num(_list[i]).compareTo(n) == 0 ? 1 : 0;
+		}
+		return new DoubleList(out);
+	}
+
+	@Override
+	public NumberList eq(NumberList ns) {
+		boundsCheck(this, ns);
+		int len = _list.length;
+		double[] out = new double[len];
+		if (ns instanceof DoubleList) {
+			final DoubleList NS = (DoubleList)ns;
+			for (int i = 0; i < len; i++) out[i] = _list[i] == NS._list[i] ? 1 : 0;
+		} else  {
+			for (int i = 0; i < len; i++) out[i] = new Num(_list[i]).compareTo(ns.get(i)) == 0 ? 1 : 0;
+		}
+		return new DoubleList(out);
+	}
+
+}

--- a/src/aya/obj/list/numberlist/DoubleList.java
+++ b/src/aya/obj/list/numberlist/DoubleList.java
@@ -13,6 +13,7 @@ import aya.obj.list.ListAlgorithms;
 import aya.obj.list.ListImpl;
 import aya.obj.number.Num;
 import aya.obj.number.Number;
+import aya.util.Casting;
 import aya.util.MathUtils;
 
 /** List containing a list of Number objects */
@@ -530,10 +531,22 @@ public class DoubleList extends NumberList {
 	}
 
 	@Override
-	public void rotate(int n) {
-		NumberItemList ns = toNumberItemList();
-		ns.rotate(n);
-		_list = ns.todoubleArray();
+	public ListImpl rotate(int n) {
+		if (n == 0) {
+			return new DoubleList(Arrays.copyOf(_list, _list.length));
+		} else {
+			final int len = _list.length;
+			double[] out = new double[len];
+			if (n > 0) {
+				System.arraycopy(_list, 0, out, n, len - n);
+				System.arraycopy(_list, len-n, out, 0, n);
+			} else {
+				n *= -1;
+				System.arraycopy(_list, 0, out, len-n, n);
+				System.arraycopy(_list, n, out, 0, len-n);
+			}
+			return new DoubleList(out);
+		}
 	}
 
 	@Override

--- a/src/aya/obj/list/numberlist/DoubleList.java
+++ b/src/aya/obj/list/numberlist/DoubleList.java
@@ -1147,4 +1147,17 @@ public class DoubleList extends NumberList {
 		return this;
 	}
 
+	public static List transpose2d(ArrayList<DoubleList> lists) {
+		final int in_rows = lists.size();
+		final int in_cols = lists.get(0).length();
+		double[][] trans = new double[in_cols][in_rows];
+		ArrayList<Obj> out = new ArrayList<Obj>(in_cols);
+		for (int i = 0; i < in_cols; i++) {
+			for (int j = 0; j < in_rows; j++) {
+				trans[i][j] = lists.get(j)._list[i];
+			}
+			out.add(new List(new DoubleList(trans[i])));
+		}
+		return new List(out);
+	}
 }

--- a/src/aya/obj/list/numberlist/DoubleList.java
+++ b/src/aya/obj/list/numberlist/DoubleList.java
@@ -491,12 +491,12 @@ public class DoubleList extends NumberList {
 
 	@Override
 	public DoubleList head(int n) {
-		return new DoubleList(ListAlgorithms.headNoDeepcopyPad(_list, n, Num.ZERO));
+		return new DoubleList(ListAlgorithms.headNoDeepcopyPad(_list, n, 0));
 	}
 
 	@Override
 	public DoubleList tail(int n) {
-		return new DoubleList(ListAlgorithms.tailNoDeepcopyPad(_list, n, Num.ZERO));
+		return new DoubleList(ListAlgorithms.tailNoDeepcopyPad(_list, n, 0));
 	}
 
 	@Override
@@ -511,76 +511,96 @@ public class DoubleList extends NumberList {
 
 	@Override
 	public Number pop() {
-		return _list.remove(0);
+		NumberItemList ns = toNumberItemList();
+		Number n = ns.pop();
+		_list = ns.todoubleArray();
+		return n;
 	}
 
 	@Override
 	public Number popBack() {
-		return _list.remove(_list.length-1);
+		NumberItemList ns = toNumberItemList();
+		Number n = ns.popBack();
+		_list = ns.todoubleArray();
+		return n;
 	}
 
 	@Override
 	public void reverse() {
-		Collections.reverse(_list);
+		NumberItemList ns = toNumberItemList();
+		ns.reverse();
+		_list = ns.todoubleArray();
 	}
 
 	@Override
 	public void rotate(int n) {
-		ListAlgorithms.rotate(_list, n);
+		NumberItemList ns = toNumberItemList();
+		ns.rotate(n);
+		_list = ns.todoubleArray();
 	}
 
 	@Override
 	public DoubleList slice(int i, int j) {
-		return new DoubleList(ListAlgorithms.slice(_list, i, j));
+		NumberItemList ns = toNumberItemList();
+		return new DoubleList(ns.slice(i, j).todoubleArray());
 	}
 
 	@Override
 	public Number get(int i) {
-		return _list[i];
+		return new Num(_list[i]);
 	}
 	
 	@Override
 	public DoubleList get(int[] is) {
-		ArrayList<Number> out = new ArrayList<Number>(is.length);
-		for (int i : is) {
-			out.add(_list[i]);
+		double[] out = new double[is.length];
+		for (int i = 0; i < is.length; i++) {
+			out[i] = _list[i];
 		}
 		return new DoubleList(out);
 	}
 	
 	@Override
 	public Number remove(int i) {
-		return _list.remove(i);
+		NumberItemList ns = toNumberItemList();
+		Number n = ns.remove(i);
+		_list = ns.todoubleArray();
+		return n;
 	}
 	
 	@Override
 	public void removeAll(int[] ixs) {
-		ListAlgorithms.removeAll(_list, ixs);
+		NumberItemList ns = toNumberItemList();
+		ns.removeAll(ixs);
+		_list = ns.todoubleArray();
 	}
 
 	@Override
 	public int find(Obj o) {
-		return ListAlgorithms.find(_list, o);
+		return toNumberItemList().find(o);
 	}
 
 	@Override
 	public DoubleList findAll(Obj o) {
-		return new DoubleList(ListAlgorithms.findAll(_list, o));
+		return new DoubleList(toNumberItemList().findAll(o).todoubleArray());
 	}
 
 	@Override
 	public int findBack(Obj o) {
-		return ListAlgorithms.findBack(_list, o);
+		return toNumberItemList().findBack(o);
 	}
 
 	@Override
 	public int count(Obj o) {
-		return ListAlgorithms.count(_list, o);
+		if (o.isa(Obj.NUMBER)) {
+			return ListAlgorithms.count(_list, asNumber(o).toDouble());
+		} else {
+			return 0;
+		}
 	}
 	
 	@Override
 	public void sort() {
-		Collections.sort(_list);
+		Arrays.sort(_list);
 	}
 	
 	@Override
@@ -599,7 +619,7 @@ public class DoubleList extends NumberList {
 	
 	@Override
 	public DoubleList unique() {
-		return new DoubleList(ListAlgorithms.unique(_list));
+		return new DoubleList(toNumberItemList().unique().todoubleArray());
 	}
 	
 	
@@ -611,12 +631,16 @@ public class DoubleList extends NumberList {
 
 	@Override
 	public void addItem(Obj o) {
-		_list.add((Number)o);
+		double[] list = Arrays.copyOf(_list, _list.length + 1);
+		list[list.length - 1] = asNumber(o).toDouble();
+		_list = list;
 	}
 	
 	@Override
 	public void addItem(int i, Obj o) {
-		_list.add(i, (Number)o);
+		NumberItemList ns = toNumberItemList();
+		ns.addItem(i, o);
+		_list = ns.todoubleArray();
 	}
 
 	@Override
@@ -655,11 +679,7 @@ public class DoubleList extends NumberList {
 	
 	@Override
 	public List split(Obj o) {
-		if (o.isa(Obj.NUMBER)) {
-			return List.from2DTemplate(ListAlgorithms.split(this._list, Casting.asNumber(o)));
-		} else {
-			return new List();
-		}
+		return toNumberItemList().split(o);
 	}
 	
 	
@@ -680,12 +700,12 @@ public class DoubleList extends NumberList {
 
 	@Override
 	public ReprStream repr(ReprStream stream) {
-		return ListAlgorithms.reprCompact(stream, _list);
+		return toNumberItemList().repr(stream);
 	}
 
 	@Override
 	public String str() {
-		return ListAlgorithms.str(_list);
+		return toNumberItemList().str();
 	}
 
 	@Override
@@ -1116,6 +1136,12 @@ public class DoubleList extends NumberList {
 			for (int i = 0; i < len; i++) out[i] = new Num(_list[i]).compareTo(ns.get(i)) == 0 ? 1 : 0;
 		}
 		return new DoubleList(out);
+	}
+
+	private NumberItemList toNumberItemList() {
+		ArrayList<Number> out = new ArrayList<Number>();
+		for (double d : _list) out.add(new Num(d));
+		return new NumberItemList(out);
 	}
 
 }

--- a/src/aya/obj/list/numberlist/DoubleList.java
+++ b/src/aya/obj/list/numberlist/DoubleList.java
@@ -4,7 +4,6 @@ import static aya.util.Casting.asNumber;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 
 import aya.ReprStream;
 import aya.exceptions.runtime.ValueError;
@@ -14,8 +13,6 @@ import aya.obj.list.ListAlgorithms;
 import aya.obj.list.ListImpl;
 import aya.obj.number.Num;
 import aya.obj.number.Number;
-import aya.obj.number.NumberMath;
-import aya.util.Casting;
 import aya.util.MathUtils;
 
 /** List containing a list of Number objects */
@@ -580,8 +577,8 @@ public class DoubleList extends NumberList {
 	}
 
 	@Override
-	public DoubleList findAll(Obj o) {
-		return new DoubleList(toNumberItemList().findAll(o).todoubleArray());
+	public NumberList findAll(Obj o) {
+		return toNumberItemList().findAll(o);
 	}
 
 	@Override
@@ -605,7 +602,7 @@ public class DoubleList extends NumberList {
 	
 	@Override
 	public void set(int i, Obj o) {
-		_list[i] = asNumber(o).toDouble();
+		_list[i] = ((Num)o).toDouble();
 	}
 	
 	@Override
@@ -619,7 +616,7 @@ public class DoubleList extends NumberList {
 	
 	@Override
 	public DoubleList unique() {
-		return new DoubleList(toNumberItemList().unique().todoubleArray());
+		return new DoubleList(toNumberItemList().unique().toNumberList().todoubleArray());
 	}
 	
 	
@@ -632,14 +629,14 @@ public class DoubleList extends NumberList {
 	@Override
 	public void addItem(Obj o) {
 		double[] list = Arrays.copyOf(_list, _list.length + 1);
-		list[list.length - 1] = asNumber(o).toDouble();
+		list[list.length - 1] = ((Num)o).toDouble();
 		_list = list;
 	}
 	
 	@Override
 	public void addItem(int i, Obj o) {
 		NumberItemList ns = toNumberItemList();
-		ns.addItem(i, o);
+		ns.addItem(i, (Num)o);
 		_list = ns.todoubleArray();
 	}
 
@@ -700,7 +697,8 @@ public class DoubleList extends NumberList {
 
 	@Override
 	public ReprStream repr(ReprStream stream) {
-		return toNumberItemList().repr(stream);
+		stream.print("d");
+		return ListAlgorithms.reprCompact(stream, _list);
 	}
 
 	@Override

--- a/src/aya/obj/list/numberlist/NumberItemList.java
+++ b/src/aya/obj/list/numberlist/NumberItemList.java
@@ -28,6 +28,10 @@ public class NumberItemList extends NumberList {
 		for (Number n : list) incDoubleCounter(n);
 	}
 
+	public static NumberItemList test_fromAL(ArrayList<Number> list) {
+		return new NumberItemList(list);
+	}
+
 	// Use NumberList.fromNumberAL outside of package
 	protected NumberItemList(ArrayList<Number> list, int num_doubles) {
 		_list = list;
@@ -465,8 +469,10 @@ public class NumberItemList extends NumberList {
 	}
 
 	@Override
-	public void rotate(int n) {
-		ListAlgorithms.rotate(_list, n);
+	public ListImpl rotate(int n) {
+		ArrayList<Number> out = new ArrayList<>(_list);
+		ListAlgorithms.rotate(out, n);
+		return new NumberItemList(out);
 	}
 
 	@Override

--- a/src/aya/obj/list/numberlist/NumberItemList.java
+++ b/src/aya/obj/list/numberlist/NumberItemList.java
@@ -74,6 +74,14 @@ public class NumberItemList extends NumberList {
 		return new NumberItemList(out);
 	}
 
+	public static NumberItemList fromDoubles(double[] doubles) {
+		ArrayList<Number> out = new ArrayList<Number>(doubles.length);
+		for (int i = 0; i < doubles.length; i++) {
+			out.add(new Num(doubles[i]));
+		}
+		return new NumberItemList(out);
+	}
+
 	//////////////////////////
 	// NUMBERLIST OVERRIDES //
 	//////////////////////////

--- a/src/aya/obj/list/numberlist/NumberItemList.java
+++ b/src/aya/obj/list/numberlist/NumberItemList.java
@@ -3,7 +3,6 @@ package aya.obj.list.numberlist;
 import static aya.util.Casting.asNumber;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 
 import aya.ReprStream;
@@ -510,8 +509,8 @@ public class NumberItemList extends NumberList {
 	}
 
 	@Override
-	public NumberItemList findAll(Obj o) {
-		return new NumberItemList(ListAlgorithms.findAll(_list, o));
+	public NumberList findAll(Obj o) {
+		return NumberList.fromNumberAL(ListAlgorithms.findAll(_list, o));
 	}
 
 	@Override

--- a/src/aya/obj/list/numberlist/NumberItemList.java
+++ b/src/aya/obj/list/numberlist/NumberItemList.java
@@ -21,20 +21,48 @@ import aya.util.Casting;
 public class NumberItemList extends NumberList {
 	
 	ArrayList<Number> _list;
+	private int _doubles = 0;
 	
-	public NumberItemList(ArrayList<Number> list) {
+	// Use NumberList.fromNumberAL outside of package
+	protected NumberItemList(ArrayList<Number> list) {
 		_list = list;
+		for (Number n : list) incDoubleCounter(n);
+	}
+
+	// Use NumberList.fromNumberAL outside of package
+	protected NumberItemList(ArrayList<Number> list, int num_doubles) {
+		_list = list;
+		_doubles = num_doubles;
+	}
+
+	@Override
+	public NumberList promote() {
+		final int len = _list.size();
+		if (_doubles == len) {
+			double[] out = new double[len];
+			for (int i = 0; i < len; i++) {
+				out[i] = _list.get(i).toDouble();
+			}
+			return new DoubleList(out);
+		} else {
+			return this;
+		}
 	}
 	
+
 	/** Create a new numeric list by repeating item, repeats times */
-	public NumberItemList(Number item, int repeats) {
+	// Use NumberList.repeat outside of package
+	protected NumberItemList(Number item, int repeats) {
 		_list = new ArrayList<Number>(repeats);
 		for (int i = 0; i < repeats; i++) {
 			_list.add(item);
 		}
+		if (item.isa(Obj.NUM)) {
+			_doubles = _list.size();
+		}
 	}
 	
-	public NumberItemList(Number lo, Number hi, Number inc) {
+	protected NumberItemList(Number lo, Number hi, Number inc) {
 		//Calculate the number of items, this will return a negative value if array creation is impossible
  		int numOfItems = NumberMath.div(NumberMath.sub(hi, lo), inc).floor().toInt() + 1;
 	
@@ -62,26 +90,6 @@ public class NumberItemList extends NumberList {
 	}
 	
 	
-	//////////////
-	// Creation //
-	//////////////
-
-	public static NumberItemList fromBytes(byte[] bytes) {
-		ArrayList<Number> out = new ArrayList<Number>(bytes.length);
-		for (int i = 0; i < bytes.length; i++) {
-			out.add(Num.fromByte(bytes[i]));
-		}
-		return new NumberItemList(out);
-	}
-
-	public static NumberItemList fromDoubles(double[] doubles) {
-		ArrayList<Number> out = new ArrayList<Number>(doubles.length);
-		for (int i = 0; i < doubles.length; i++) {
-			out.add(new Num(doubles[i]));
-		}
-		return new NumberItemList(out);
-	}
-
 	//////////////////////////
 	// NUMBERLIST OVERRIDES //
 	//////////////////////////
@@ -440,12 +448,16 @@ public class NumberItemList extends NumberList {
 
 	@Override
 	public Number pop() {
-		return _list.remove(0);
+		final Number n = _list.remove(0);
+		decDoubleCounter(n);
+		return n;
 	}
 
 	@Override
 	public Number popBack() {
-		return _list.remove(_list.size()-1);
+		final Number n = _list.remove(_list.size()-1);
+		decDoubleCounter(n);
+		return n;
 	}
 
 	@Override
@@ -479,12 +491,17 @@ public class NumberItemList extends NumberList {
 	
 	@Override
 	public Number remove(int i) {
-		return _list.remove(i);
+		Number n = _list.remove(i);
+		decDoubleCounter(n);
+		return n;
 	}
 	
 	@Override
 	public void removeAll(int[] ixs) {
 		ListAlgorithms.removeAll(_list, ixs);
+		// Re-compute counters
+		_doubles = 0;
+		for (Number n : _list) incDoubleCounter(n);
 	}
 
 	@Override
@@ -540,12 +557,16 @@ public class NumberItemList extends NumberList {
 
 	@Override
 	public void addItem(Obj o) {
-		_list.add((Number)o);
+		final Number n = (Number)o;
+		_list.add(n);
+		incDoubleCounter(n);
 	}
 	
 	@Override
 	public void addItem(int i, Obj o) {
-		_list.add(i, (Number)o);
+		final Number n = (Number)o;
+		_list.add(i, n);
+		incDoubleCounter(n);
 	}
 
 	@Override
@@ -559,7 +580,7 @@ public class NumberItemList extends NumberList {
 	public NumberItemList copy() {
 		ArrayList<Number> out = emptyAL();
 		out.addAll(_list);
-		return new NumberItemList(out);
+		return new NumberItemList(out, _doubles);
 	}
 	
 	@Override
@@ -603,7 +624,7 @@ public class NumberItemList extends NumberList {
 		for (int i = 0; i < _list.size(); i++) {
 			copy.add(_list.get(i).deepcopy());
 		}
-		return new NumberItemList(copy);	
+		return new NumberItemList(copy, _doubles);	
 	}
 
 	@Override
@@ -651,33 +672,6 @@ public class NumberItemList extends NumberList {
 	// HELPER FUNCTIONS //
 	//////////////////////
 	
-	/** Primes up to n **/
-	public static NumberItemList primes(int n) {
-		boolean[] flags = new boolean[n];
-		Arrays.fill(flags, true);
-		
-		//Mark every space that is not prime
-		for (int i = 2; i <= n; i++) {
-			int z = 2*i;
-			while (z <= n) {
-				flags[z-1] = false; //zero index, so sub 1
-				z += i;
-			}
-		}
-		
-		//Allocate new array
-		ArrayList<Number> primeList = new ArrayList<Number>();
-		
-		//Add primes into array
-		for (int i = 2; i <= n; i++) {
-			if (flags[i-1]) {
-				primeList.add(Num.fromInt(i));
-			}
-		}
-		
-		return new NumberItemList(primeList);
-	}
-
 	private void boundsCheck(NumberList a, NumberList b) {
 		if (a.length() != b.length())
 			throw new ValueError("List length mismatch\n"
@@ -816,48 +810,51 @@ public class NumberItemList extends NumberList {
 		return new NumberItemList(out);
 	}
 
+
+
+
 	@Override
 	public NumberList band(NumberList ns) {
 		boundsCheck(this, ns);
 		int len = ns.length();
-		ArrayList<Number> out = new ArrayList<Number>(len);
+		double[] out = new double[len];
 		for (int i = 0; i < len; i++) {
-			out.add(NumberMath.band(this.get(i), ns.get(i)));
+			out[i] = NumberMath.band(this.get(i), ns.get(i)).toDouble();
 		}
-		return new NumberItemList(out);
+		return new DoubleList(out);
 	}
 
 	@Override
 	public NumberList bandFrom(NumberList ns) {
 		boundsCheck(this, ns);
 		int len = ns.length();
-		ArrayList<Number> out = new ArrayList<Number>(len);
+		double[] out = new double[len];
 		for (int i = 0; i < len; i++) {
-			out.add(NumberMath.band(ns.get(i), this.get(i)));
+			out[i] = NumberMath.band(ns.get(i), this.get(i)).toDouble();
 		}
-		return new NumberItemList(out);
+		return new DoubleList(out);
 	}
 
 	@Override
 	public NumberList bor(NumberList ns) {
 		boundsCheck(this, ns);
 		int len = ns.length();
-		ArrayList<Number> out = new ArrayList<Number>(len);
+		double[] out = new double[len];
 		for (int i = 0; i < len; i++) {
-			out.add(NumberMath.bor(this.get(i), ns.get(i)));
+			out[i] = NumberMath.bor(this.get(i), ns.get(i)).toDouble();
 		}
-		return new NumberItemList(out);
+		return new DoubleList(out);
 	}
 
 	@Override
 	public NumberList borFrom(NumberList ns) {
 		boundsCheck(this, ns);
 		int len = ns.length();
-		ArrayList<Number> out = new ArrayList<Number>(len);
+		double[] out = new double[len];
 		for (int i = 0; i < len; i++) {
-			out.add(NumberMath.bor(ns.get(i), this.get(i)));
+			out[i] = NumberMath.bor(ns.get(i), this.get(i)).toDouble();
 		}
-		return new NumberItemList(out);
+		return new DoubleList(out);
 	}
 
 	
@@ -865,106 +862,120 @@ public class NumberItemList extends NumberList {
 	@Override
 	public NumberList lt(Number n) {
 		int len = _list.size();
-		ArrayList<Number> out = new ArrayList<Number>(len);
+		double[] out = new double[len];
 		for (int i = 0; i < len; i++) {
-			out.add(Num.fromBool(_list.get(i).compareTo(n) < 0));
+			out[i] = _list.get(i).compareTo(n) < 0 ? 1 : 0;
 		}
-		return new NumberItemList(out);
+		return new DoubleList(out);
 	}
 
 	@Override
 	public NumberList lt(NumberList ns) {
 		boundsCheck(this, ns);
 		int len = _list.size();
-		ArrayList<Number> out = new ArrayList<Number>(len);
+		double[] out = new double[len];
 		for (int i = 0; i < len; i++) {
-			out.add(Num.fromBool(_list.get(i).compareTo(ns.get(i)) < 0));
+			out[i] = _list.get(i).compareTo(ns.get(i)) < 0 ? 1 : 0;
 		}
-		return new NumberItemList(out);
+		return new DoubleList(out);
 	}
 
 	@Override
 	public NumberList leq(Number n) {
 		int len = _list.size();
-		ArrayList<Number> out = new ArrayList<Number>(len);
+		double[] out = new double[len];
 		for (int i = 0; i < len; i++) {
-			out.add(Num.fromBool(_list.get(i).compareTo(n) <= 0));
+			out[i] = _list.get(i).compareTo(n) <= 0 ? 1 : 0;
 		}
-		return new NumberItemList(out);
+		return new DoubleList(out);
 	}
 
 	@Override
 	public NumberList leq(NumberList ns) {
 		boundsCheck(this, ns);
 		int len = _list.size();
-		ArrayList<Number> out = new ArrayList<Number>(len);
+		double[] out = new double[len];
 		for (int i = 0; i < len; i++) {
-			out.add(Num.fromBool(_list.get(i).compareTo(ns.get(i)) <= 0));
+			out[i] = _list.get(i).compareTo(ns.get(i)) <= 0 ? 1 : 0;
 		}
-		return new NumberItemList(out);
+		return new DoubleList(out);
 	}
 
 	@Override
 	public NumberList gt(Number n) {
 		int len = _list.size();
-		ArrayList<Number> out = new ArrayList<Number>(len);
+		double[] out = new double[len];
 		for (int i = 0; i < len; i++) {
-			out.add(Num.fromBool(_list.get(i).compareTo(n) > 0));
+			out[i] = _list.get(i).compareTo(n) > 0 ? 1 : 0;
 		}
-		return new NumberItemList(out);
+		return new DoubleList(out);
 	}
 
 	@Override
 	public NumberList gt(NumberList ns) {
 		boundsCheck(this, ns);
 		int len = _list.size();
-		ArrayList<Number> out = new ArrayList<Number>(len);
+		double[] out = new double[len];
 		for (int i = 0; i < len; i++) {
-			out.add(Num.fromBool(_list.get(i).compareTo(ns.get(i)) > 0));
+			out[i] = _list.get(i).compareTo(ns.get(i)) > 0 ? 1 : 0;
 		}
-		return new NumberItemList(out);
+		return new DoubleList(out);
 	}
 
 	@Override
 	public NumberList geq(Number n) {
 		int len = _list.size();
-		ArrayList<Number> out = new ArrayList<Number>(len);
+		double[] out = new double[len];
 		for (int i = 0; i < len; i++) {
-			out.add(Num.fromBool(_list.get(i).compareTo(n) >= 0));
+			out[i] = _list.get(i).compareTo(n) >= 0 ? 1 : 0;
 		}
-		return new NumberItemList(out);
+		return new DoubleList(out);
 	}
 
 	@Override
 	public NumberList geq(NumberList ns) {
 		boundsCheck(this, ns);
 		int len = _list.size();
-		ArrayList<Number> out = new ArrayList<Number>(len);
+		double[] out = new double[len];
 		for (int i = 0; i < len; i++) {
-			out.add(Num.fromBool(_list.get(i).compareTo(ns.get(i)) >= 0));
+			out[i] = _list.get(i).compareTo(ns.get(i)) >= 0 ? 1 : 0;
 		}
-		return new NumberItemList(out);
+		return new DoubleList(out);
 	}
 
 	@Override
 	public NumberList eq(Number n) {
 		int len = _list.size();
-		ArrayList<Number> out = new ArrayList<Number>(len);
+		double[] out = new double[len];
 		for (int i = 0; i < len; i++) {
-			out.add(Num.fromBool(_list.get(i).compareTo(n) == 0));
+			out[i] = _list.get(i).compareTo(n) == 0 ? 1 : 0;
 		}
-		return new NumberItemList(out);
+		return new DoubleList(out);
 	}
 
 	@Override
 	public NumberList eq(NumberList ns) {
 		boundsCheck(this, ns);
 		int len = _list.size();
-		ArrayList<Number> out = new ArrayList<Number>(len);
+		double[] out = new double[len];
 		for (int i = 0; i < len; i++) {
-			out.add(Num.fromBool(_list.get(i).compareTo(ns.get(i)) == 0));
+			out[i] = _list.get(i).compareTo(ns.get(i)) == 0 ? 1 : 0;
 		}
-		return new NumberItemList(out);
+		return new DoubleList(out);
 	}
+
+
+	private void incDoubleCounter(Number n) {
+		if (n.isa(Obj.NUM)) {
+			_doubles++;
+		}
+	}
+
+	private void decDoubleCounter(Number n) {
+		if (n.isa(Obj.NUM)) {
+			_doubles--;
+		}
+	}
+
 
 }

--- a/src/aya/obj/list/numberlist/NumberList.java
+++ b/src/aya/obj/list/numberlist/NumberList.java
@@ -29,6 +29,18 @@ public abstract class NumberList extends ListImpl {
 		}
 	}
 
+	public static DoubleList fromBytes(byte[] bytes) {
+		return DoubleList.fromBytes(bytes);
+	}
+
+	public static DoubleList fromChars(char[] chars) {
+		double[] out = new double[chars.length];
+		for (int i = 0; i < chars.length; i++) {
+			out[i] = (char)chars[i];
+		}
+		return new DoubleList(out);
+	}
+
 	/////////////////////
 	// LIST OPERATIONS //
 	/////////////////////

--- a/src/aya/obj/list/numberlist/NumberList.java
+++ b/src/aya/obj/list/numberlist/NumberList.java
@@ -2,11 +2,32 @@ package aya.obj.list.numberlist;
 
 import java.util.ArrayList;
 
+import aya.obj.Obj;
 import aya.obj.list.ListImpl;
 import aya.obj.number.Number;
 
 /** Supertype for all lists containing only numbers */
 public abstract class NumberList extends ListImpl {
+
+	public static NumberList repeat(Number item, int repeats) {
+		if (item.isa(Obj.NUM)) {
+			return new DoubleList(item.toDouble(), repeats);
+		} else {
+			return new NumberItemList(item, repeats).promote();
+		}
+	}
+
+	public static NumberList fromNumberAL(ArrayList<Number> list) {
+		return new NumberItemList(list).promote();
+	}
+
+	public static NumberList range(Number lo, Number hi, Number inc) {
+		if (lo.isa(Obj.NUM) && hi.isa(Obj.NUM) && inc.isa(Obj.NUM)) {
+			return new DoubleList(lo.toDouble(), hi.toDouble(), inc.toDouble());
+		} else {
+			return new NumberItemList(lo, hi, inc).promote();
+		}
+	}
 
 	/////////////////////
 	// LIST OPERATIONS //
@@ -196,6 +217,9 @@ public abstract class NumberList extends ListImpl {
 	
 	@Override
 	public abstract Number get(int i);
+
+	@Override
+	public abstract NumberList promote();
 
 
 	

--- a/src/aya/obj/number/BaseConversion.java
+++ b/src/aya/obj/number/BaseConversion.java
@@ -3,13 +3,12 @@ package aya.obj.number;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
-import java.util.ArrayList;
 
 import aya.exceptions.runtime.TypeError;
 import aya.exceptions.runtime.ValueError;
 import aya.obj.Obj;
 import aya.obj.list.List;
-import aya.obj.list.numberlist.NumberItemList;
+import aya.obj.list.numberlist.DoubleList;
 import aya.obj.list.numberlist.NumberList;
 import aya.util.Casting;
 
@@ -81,20 +80,15 @@ public class BaseConversion {
 			}
 		} else if (to_base == 2) {
 			String bin_str = out_bi.toString(2);
-			ArrayList<Number> out_list = new ArrayList<Number>(bin_str.length());
-			
-			for (char c : bin_str.toCharArray()) {
-				out_list.add(new Num(c-'0'));
+			char[] cs = bin_str.toCharArray();
+			double[] out = new double[cs.length];
+			for (int i = 0; i < out.length; i++) {
+				out[i] = (double)(cs[i] - '0');
 			}
-			return new List(new NumberItemList(out_list));
+			return new List(new DoubleList(out));
 		} else if (to_base == 0) {
 			// Special case: byte list
-			byte[] bytes = out_bi.toByteArray();
-			ArrayList<Number> nums = new ArrayList<>(bytes.length);
-			for (byte b : bytes) {
-				nums.add(Num.fromByte(b));
-			}
-			return new List(new NumberItemList(nums));
+			return new List(NumberList.fromBytes(out_bi.toByteArray()));
 		} else {
 			return List.fromString(out_bi.toString(to_base));
 		}

--- a/src/test/obj/list/numberlist/NumberItemListTest.java
+++ b/src/test/obj/list/numberlist/NumberItemListTest.java
@@ -14,7 +14,7 @@ public class NumberItemListTest extends Test {
 		for (Double d : doubles) {
 			ns.add(new Num(d));
 		}
-		return new NumberItemList(ns);
+		return NumberItemList.test_fromAL(ns);
 	}
 	
 	private static NumberItemList ls(Integer...ints) {
@@ -22,11 +22,11 @@ public class NumberItemListTest extends Test {
 		for (Integer i : ints) {
 			ns.add(new Num(i));
 		}
-		return new NumberItemList(ns);
+		return NumberItemList.test_fromAL(ns);
 	}
 	
 	private static NumberItemList ls() {
-		return new NumberItemList(new ArrayList<Number>(0));
+		return NumberItemList.test_fromAL(new ArrayList<Number>(0));
 	}
 	
 	private static Num num(int i) {
@@ -80,12 +80,12 @@ public class NumberItemListTest extends Test {
 			lnOneSix_AL.add(num(Math.log(i)));
 			sqrtOneSix_AL.add(num(Math.sqrt(i)));
 		}
-		NumberItemList sinOneSix  = new NumberItemList(sinOneSix_AL);
-		NumberItemList cosOneSix  = new NumberItemList(cosOneSix_AL);
-		NumberItemList tanOneSix  = new NumberItemList(tanOneSix_AL);
-		NumberItemList logOneSix  = new NumberItemList(logOneSix_AL);
-		NumberItemList lnOneSix   = new NumberItemList(lnOneSix_AL);
-		NumberItemList sqrtOneSix = new NumberItemList(sqrtOneSix_AL);
+		NumberItemList sinOneSix  = NumberItemList.test_fromAL(sinOneSix_AL);
+		NumberItemList cosOneSix  = NumberItemList.test_fromAL(cosOneSix_AL);
+		NumberItemList tanOneSix  = NumberItemList.test_fromAL(tanOneSix_AL);
+		NumberItemList logOneSix  = NumberItemList.test_fromAL(logOneSix_AL);
+		NumberItemList lnOneSix   = NumberItemList.test_fromAL(lnOneSix_AL);
+		NumberItemList sqrtOneSix = NumberItemList.test_fromAL(sqrtOneSix_AL);
 		
 		Test.eq(oneSix.sin() , sinOneSix , "sin" );
 		Test.eq(oneSix.cos() , cosOneSix , "cos" );


### PR DESCRIPTION
Requires #78 

Adds an optimized `ListImpl` for lists of doubles only.
Math operations happen directly on the data in `double[]` and no longer need to use `Number` wrappers or `NumberMath`. The result is much faster vectorized operations.  

Additionally, many of the algorithms (slice, rotate, ect.) have been optimized.

Still working on some proper benchmarks but here are some examples:

```
aya-0.3> 10000R:l; {{l 1+ 2- 3/ 4* 1.05^ ;} 10000 %}.time
5788 .# 5.8 seconds
aya-0.4> 10000R:l; {{l 1+ 2- 3/ 4* 1.05^ ;} 10000 %}.time
2186 .# 2.2 seconds
```