### PR TITLE
Bugfix/graphics npe

### DIFF
--- a/src/aya/ext/graphics/instruction/cursor/MoveEventsInstruction.java
+++ b/src/aya/ext/graphics/instruction/cursor/MoveEventsInstruction.java
@@ -1,5 +1,6 @@
 package aya.ext.graphics.instruction.cursor;
 
+import aya.exceptions.runtime.ValueError;
 import aya.ext.graphics.Canvas;
 import aya.ext.graphics.CanvasCursorListener;
 import aya.ext.graphics.CanvasTable;
@@ -16,10 +17,14 @@ public class MoveEventsInstruction  extends GraphicsInstruction {
 
 	@Override
 	protected void doCanvasCommand(Canvas cvs, Block block) {
-		block.push(
-				cvs.getCursorListener().getMoveHistory().stream()
-						.map(CanvasCursorListener.MoveInfo::toDict)
-						.collect(new ListCollector())
-		);
+		try {
+			block.push(
+					cvs.getCursorListener().getMoveHistory().stream()
+							.map(CanvasCursorListener.MoveInfo::toDict)
+							.collect(new ListCollector())
+			);
+		} catch (NullPointerException e) {
+			throw new ValueError(e.getMessage());
+		}
 	}
 }

--- a/std/canvas.aya
+++ b/std/canvas.aya
@@ -166,3 +166,11 @@ def canvas::pressed_buttons {self,
 def canvas::typed_chars {self,
     self.id :{graphics.typed_chars}
 }
+
+def canvas::pressed_keys {self,
+    self.id :{graphics.pressed_keys}
+}
+
+def canvas::text {self,
+    self.id :{graphics.text}
+}


### PR DESCRIPTION
 - Fix uncaught null pointer exception in move events instruction
 - Add missing graphics.text and graphics.pressed_keys to `canvas`