### PR TITLE
Fix std/io '_isabs' and '__str__' for windows

### DIFF
--- a/std/io.aya
+++ b/std/io.aya
@@ -5,8 +5,6 @@ export [
     ::stdin
 ]
 
-def ::iswindows {:9s"\\"=}
-
 
 class path
 
@@ -62,7 +60,7 @@ def path::__radd__ {\.__add__}
 .# String representation of the path
 def path::__str__ {self,
     self.dirs "/" %
-    self.is_absolute_path {
+    self.is_absolute_path self._iswindows ! & {
         "/" \ +
     } ?
     .#self.dirs :9s % self.M.root :9s + \+
@@ -129,10 +127,11 @@ def path::_fixhome {dirs::list path,
 
 .# ::str path._isabs\n  return true of the given string is an absolute path
 def path::_isabs {p::str path,
-    p "/" N0=\;
-    p path.root :9s + N0=\;
-    p path.root "/" + N0=\;
-    | |
+	path._iswindows {
+		p 1 I ': =
+	} {
+		p "/" N0=\;
+	} .?
 }
 
 .# Remove all ".." by traversing the directories
@@ -157,6 +156,10 @@ def path::_clean {dirs::list path : i(0),
     dirs
 }
 
+def path::_iswindows {self,
+	:9s "\\" =
+}
+
 
 
 .#
@@ -165,12 +168,6 @@ def path::_clean {dirs::list path : i(0),
 
 .#? path.root\n  root dir name
 "user.dir" :{sys.getprop} :9s .^ S .[0] path.:root;
-
-
-.# Regular expression used for splitting path strings
-.# If :9s is "\", return escaped "\\" otherwise return :9s
-.#? path.filesplit\n  constant "\\" if windows, "/" if unix
-iswindows {:9s$+} {:9s} .? path.:filesplit;
 
 
 


### PR DESCRIPTION
Currently `_isabs` does not work for paths in drives that are not the Aya's root drive.
E.g. `"E:\\myFile.txt" path._isabs` -> `0` (wrong)
While `"D:\\myFile.txt" path._isabs` -> `1` (right)

For absolute paths `__str__` is incorrect on windows:
`"D:\\myFile.txt" path! P` -> `"/D:/myFile.txt"` (the leading / is the problem here, otherwise windows doesn't care about \ vs /)

I also removed `path.filesplit`, since that does not seem to be used anymore.

---

Note: I opted for a very simple _isabs check.
If you look at the [[Java WinNTFileSystem isAbsolute Method]](https://github.com/stain/jdk8u/blob/master/src/windows/classes/java/io/WinNTFileSystem.java#L294) you'll notice that a "proper" check is quite the headache. ('getPrefixLength' is the result of [prefixLength](https://github.com/stain/jdk8u/blob/master/src/windows/classes/java/io/WinNTFileSystem.java#L207) which in turn requires [normalize](https://github.com/stain/jdk8u/blob/master/src/windows/classes/java/io/WinNTFileSystem.java#L102) )

A more proper check supporting UNC paths might look like this:
```
{ $ '\\' = \ '/ = |} :is_slash;
(p 0 I is_slash) (p 1 I is_slash) & .# true if UNC path (absolute)
(p 0 I .isupper) (p 1 I ': =) (p 2 I is_slash) && .# true if absolute drive path
|
```
instead of `p 1 I ': =`.
But since io.aya does not support UNC anyway, and I've lived just fine without knowing about all of [this mess](https://www.fileside.app/blog/2023-03-17_windows-file-paths/), I think the simple check is fine.