### PR TITLE
Refactor internal repersentation for block

### DIFF
--- a/base/__aya__.aya
+++ b/base/__aya__.aya
@@ -1,14 +1,6 @@
 .# This file is a part of aya: https://github.com/aya-lang/aya
 
 
-.# Load tests
-{f,
-    "Loading $f..." :P
-    [:{sys.ad} :9s "$f.aya"]W :F
-}:_load;
-
-"base/test" _load
-
 .# __aya__
 .# Defines the __aya__ namespace and keywords
 

--- a/base/__aya__.aya
+++ b/base/__aya__.aya
@@ -1,5 +1,14 @@
 .# This file is a part of aya: https://github.com/aya-lang/aya
 
+
+.# Load tests
+{f,
+    "Loading $f..." :P
+    [:{sys.ad} :9s "$f.aya"]W :F
+}:_load;
+
+"base/test" _load
+
 .# __aya__
 .# Defines the __aya__ namespace and keywords
 

--- a/base/block.aya
+++ b/base/block.aya
@@ -38,7 +38,8 @@
 
 
     .#? ::block.haslocals\n  return true if the block has a local variables
-    {.|::locals H}:haslocals;
+    .# Both the args and the locals mush be empty for this to be false
+    {.| :&.locals:E \.argsE + 0 =!}:haslocals;
 
 
     .#? ::block.locals\n  get the locals of a block\n  will throw error if block does not have locals
@@ -47,43 +48,6 @@
 
     .#? ::block.args\n  get an ordered list of argument descriptions to the block\n  empty list if there are none
     {.|.args}:args;
-
-
-    .#? ::block.makelocals\n  if a block has local variables, return the block, otherwise wrap it in a block that has an empty local variable set
-    .{ Example:
-        aya> {:a, a 1 +}.makelocals
-        {: a , a 1 + }
-        aya> {a, a 1 +}.makelocals
-        {a , a 1 + }
-        aya> {a 1 +}.makelocals
-        {, {a 1 +} ~ }
-    .}
-    {f,
-        f.`.haslocals {
-            .# f has locals, simply return the block
-            f.`
-        } {
-            .# f does not have locals, wrap it in a block that does
-            {: , f~} [::f] .+
-        } .?
-    }:makelocals;
-
-
-    .#? ::list ::block.setlocals\n  wrap a block in a scope which has locals provided by the list of symbols
-    .{ Example:
-        aya> [::x] {:x; "x is $x"}.setlocals :setx
-        {: x , {:x ; "$xx is "} ~ }
-        aya> 4 setx
-        "x is 4"
-        aya> x
-        ERROR: Variable x not found
-    .}
-    {syms code,
-        {: ,_~} {, code.` :_ } .+ :code;
-        0 syms code.`.locals :D;
-        code .`
-    }:setlocals;
-
 
     .#? ::block .use ::list\n  evaulate the variables (given by a list of symbols) in the block in the current scope
     .{ Example:
@@ -102,59 +66,8 @@
         d__ .+
     })}:use;
 
-    .#? ::block .capture ::list\n  capture all vars defined in list as local variables in the block.\n  If the block has no local variables, wrap it in a block that does and return that block
-    .{ Example:
-        aya> 1:a
-        1
-        aya> {x, a x +}.capture[::a]
-        {x : a , a x + }
-        aya> 5 f
-        6
-        aya> 2:a
-        2
-        aya> 5 f
-        6
-    .}
-    {(1 hold)({\.makelocals :& .|.locals @ {}.M._capture_vars .+ ;})}:capture;
-
     .#? ::block .time\n  return the result of the block and the execution time in ms
     {:a__, M$:a__; ~ M$ a__ -} :time;
-
-    .#? ::block.where_const ::dict\n  use variables defined in D in B
-    .{ Example
-        aya> {a, a b *}.where_const {, 2:b } :double
-        {a , a 2 * }
-        aya> 3 double
-        6
-
-       Set constant values in loops.
-       Before
-        aya> 3R :# {{a, a b *}.where_const {, 10:b "evaluating..":P} ~}
-        evaluating..
-        evaluating..
-        evaluating..
-        [ 10 20 30 ]
-       After: (note the parenthesis)
-        aya> 3R :# ({a, a b *}.where_const {, 10:b "evaluating..":P})
-        evaluating..
-        [ 10 20 30 ]
-
-       Escape functions with .` and ~ :
-        aya> {a, a fn~}.where_const {, double.` :fn} :apply_double
-        {a , a {x , x 2 * } ~ }
-        aya> 2 apply_double
-        4
-
-       Nesting!
-        aya> {a, a fn~}.where_const {, {a, a b *}.where_const {, 2:b} :fn} :apply_double
-        {a , a {a , a 2 * } ~ }
-        aya> 2 apply_double
-        4
-    .}
-    {1 hold .+}:where_const;
-
-    {(1 hold)(\$\;.makelocals:&.|.locals@.+;)}:where;
-
 
     .# Utility Functions
     .#####################

--- a/base/sym.aya
+++ b/base/sym.aya
@@ -15,6 +15,13 @@
         aya> ::"Ms" .op
         Error
     .}
+    {sym, 
+        ::ops Ma
+        .# filter out items where the symbol doesn't match
+        :# {k v, v.overload sym H {v}?}
+        .# Grab the `call` block
+        :V.[0].call.`
+    }:op;
 
     .# Get a dict of all operator/symbol pairs
     {,

--- a/examples/plot/numdx.aya
+++ b/examples/plot/numdx.aya
@@ -17,11 +17,11 @@ import ::plot
 
 .# Generate a function for a tangent line at a point
 {a f : dx^,
-  {x, f_a fdx_a x a - * +}.where_const{, 
+  {x, f_a fdx_a x a - * +} {, 
     a f :f_a;
     a f.`dx :fdx_a;
     a :a;
-  }
+  } .+
 }:tangent_line;
 
 

--- a/examples/rdatasets.aya
+++ b/examples/rdatasets.aya
@@ -9,16 +9,16 @@ import ::csv
 
     "https://raw.githubusercontent.com/vincentarelbundock/Rdatasets/master/csv":url;
 
-    {name::str,
+    {name::str : url^,
         "/" `in name {
             "$url/$name.csv"
         } {
             "$url/datasets/$name.csv"
         } .?
-    }.capture[::url]:make_url;
+    }:make_url;
 
-    {name::str,
+    {name::str : make_url^,
         name make_url csv.open
-    }.capture[::make_url]:load_csv;
+    }:load_csv;
 
 }:rdatasets;

--- a/examples/vectorize.aya
+++ b/examples/vectorize.aya
@@ -4,7 +4,7 @@
 
 {f,
     .# A function which applies __x to each element in a list using :#
-    {:#{f}}.capture[::f]
+    {:f^, :#{f}}
     .# Substitute __x with the input function 'f'
 }:vectorize;
 

--- a/src/aya/instruction/BlockLiteralInstruction.java
+++ b/src/aya/instruction/BlockLiteralInstruction.java
@@ -23,7 +23,7 @@ public class BlockLiteralInstruction extends Instruction {
 	
 	public BlockLiteralInstruction(SourceStringRef source, StaticBlock b, HashMap<Symbol, StaticBlock> defaults) {
 		super(source);
-		if (defaults.size() == 0) _defaults = null;
+		if (defaults != null && defaults.size() == 0) _defaults = null;
 		_block = b;
 		_defaults = defaults;
 		_auto_eval = false;

--- a/src/aya/instruction/BlockLiteralInstruction.java
+++ b/src/aya/instruction/BlockLiteralInstruction.java
@@ -46,6 +46,7 @@ public class BlockLiteralInstruction extends Instruction {
 	public void execute(Block b) {
 		StaticBlock blk = _block;
 
+		// If there are defaults, evaluate them and push a new block
 		if (_defaults != null) {
 			Dict defaults = new Dict();
 			for (Symbol var : _defaults.keySet()) {

--- a/src/aya/instruction/BlockLiteralInstruction.java
+++ b/src/aya/instruction/BlockLiteralInstruction.java
@@ -4,7 +4,9 @@ import java.util.HashMap;
 
 import aya.ReprStream;
 import aya.obj.block.Block;
-import aya.obj.block.BlockHeader;
+import aya.obj.block.BlockUtils;
+import aya.obj.block.StaticBlock;
+import aya.obj.dict.Dict;
 import aya.obj.symbol.Symbol;
 import aya.parser.SourceStringRef;
 
@@ -15,59 +17,48 @@ import aya.parser.SourceStringRef;
  */
 public class BlockLiteralInstruction extends Instruction {
 	
-	Block _block;
-	//ArrayList<Symbol> _captures;
-	HashMap<Symbol, Block> _defaults;
+	StaticBlock _block;
+	HashMap<Symbol, StaticBlock> _defaults;
 	boolean _auto_eval;
 	
-	public BlockLiteralInstruction(SourceStringRef source, Block b, HashMap<Symbol, Block> defaults) {
+	public BlockLiteralInstruction(SourceStringRef source, StaticBlock b, HashMap<Symbol, StaticBlock> defaults) {
 		super(source);
 		if (defaults.size() == 0) _defaults = null;
 		_block = b;
 		_defaults = defaults;
 		_auto_eval = false;
 	
-		// If the block does not have a header but it has captures, create an empty one
+		// If the instruction has locals, make sure the underlying block has them as well
 		if (_defaults != null) {
-			if (_block.getHeader() == null) {
-				_block = _block.duplicateNewHeader(new BlockHeader(this.getSource()));
-			}
+			_block = BlockUtils.addLocals(_block);
 		}
 	}
 	
-	public BlockLiteralInstruction(SourceStringRef source, Block b) {
+	public BlockLiteralInstruction(SourceStringRef source, StaticBlock b) {
 		super(source);
 		_block = b;
 		_defaults = null;
 		_auto_eval = false;
 	}
 	
-	/** Collect variables, return the Block object */
-	public Block getBlock() {
-		
-		if (_defaults == null) {
-			return _block;
-		} else {
-			Block b = _block.duplicate();
-			// Create a copy of the block header
-			BlockHeader bh = b.getHeader().copy();
-			b.getInstructions().replaceHeader(bh);
-
-			for (Symbol var : _defaults.keySet()) {
-				Block dflt = _defaults.get(var).duplicate();
-				dflt.eval();
-				bh.addDefault(var, dflt.pop());
-			}
-			
-			return b;
-		}
-	}
 	
 	@Override
 	public void execute(Block b) {
-		Block blk = getBlock();
+		StaticBlock blk = _block;
+
+		if (_defaults != null) {
+			Dict defaults = new Dict();
+			for (Symbol var : _defaults.keySet()) {
+				Block evaluator = new Block();
+				evaluator.dump(_defaults.get(var));
+				evaluator.eval();
+				defaults.set(var, evaluator.pop());
+			}
+			blk = BlockUtils.mergeLocals(blk, defaults);
+		}
+		
 		if (_auto_eval) {
-			b.addAll(blk.getInstructions().getInstrucionList());
+			b.dump(blk);
 		} else {
 			b.push(blk);
 		}
@@ -76,11 +67,7 @@ public class BlockLiteralInstruction extends Instruction {
 	@Override
 	public ReprStream repr(ReprStream stream) {
 		if (_auto_eval) stream.print("(");
-		if (_defaults == null || _defaults.size() == 0) {
-			_block.repr(stream);
-		} else {
-			_block.repr(stream, true, _defaults);
-		}
+		BlockUtils.repr(stream, _block, true, _defaults);
 		if (_auto_eval) stream.print(")");
 		return stream;
 	}
@@ -89,7 +76,7 @@ public class BlockLiteralInstruction extends Instruction {
 		_auto_eval = true;
 	}
 
-	public Block getRawBlock() {
+	public StaticBlock getRawBlock() {
 		return _block;
 	}
 }

--- a/src/aya/instruction/DictLiteralInstruction.java
+++ b/src/aya/instruction/DictLiteralInstruction.java
@@ -45,12 +45,12 @@ public class DictLiteralInstruction extends Instruction {
 		
 		//Run the block
 		Block evaluator = new Block();
-		evaluator.dump(_block);
 		if (q != null) {
 			while (!q.isEmpty()) {
 				evaluator.push(q.poll());
 			}
 		}
+		evaluator.dump(_block);
 		evaluator.eval();
 		
 		//Retrieve the Dict

--- a/src/aya/instruction/DictLiteralInstruction.java
+++ b/src/aya/instruction/DictLiteralInstruction.java
@@ -7,6 +7,8 @@ import aya.Aya;
 import aya.ReprStream;
 import aya.obj.Obj;
 import aya.obj.block.Block;
+import aya.obj.block.BlockUtils;
+import aya.obj.block.StaticBlock;
 import aya.obj.dict.Dict;
 import aya.parser.SourceStringRef;
 
@@ -17,16 +19,16 @@ import aya.parser.SourceStringRef;
  */
 public class DictLiteralInstruction extends Instruction {
 	
-	Block _block;
+	StaticBlock _block;
 	private int num_captures;
 	
-	public DictLiteralInstruction(SourceStringRef source, Block b) {
+	public DictLiteralInstruction(SourceStringRef source, StaticBlock b) {
 		super(source);
 		this._block = b;
 		this.num_captures = 0;
 	}
 	
-	public DictLiteralInstruction(SourceStringRef source, Block b, int num_captures) {
+	public DictLiteralInstruction(SourceStringRef source, StaticBlock b, int num_captures) {
 		super(source);
 		this._block = b;
 		this.num_captures = num_captures;
@@ -42,13 +44,14 @@ public class DictLiteralInstruction extends Instruction {
 		Aya.getInstance().getVars().add(new Dict(), true);
 		
 		//Run the block
-		Block b2 = _block.duplicate();
+		Block evaluator = new Block();
+		evaluator.dump(_block);
 		if (q != null) {
 			while (!q.isEmpty()) {
-				b2.push(q.poll());
+				evaluator.push(q.poll());
 			}
 		}
-		b2.eval();
+		evaluator.eval();
 		
 		//Retrieve the Dict
 		return Aya.getInstance().getVars().popGet();
@@ -74,7 +77,7 @@ public class DictLiteralInstruction extends Instruction {
 		} else {
 			stream.print("{" + num_captures + ",");
 		}
-		_block.repr(stream, false);
+		BlockUtils.repr(stream, _block, false, null);
 		stream.print("}");
 		return stream;
 	}

--- a/src/aya/instruction/EmptyDictLiteralInstruction.java
+++ b/src/aya/instruction/EmptyDictLiteralInstruction.java
@@ -4,6 +4,7 @@ import java.util.Queue;
 
 import aya.obj.Obj;
 import aya.obj.block.Block;
+import aya.obj.block.StaticBlock;
 import aya.obj.dict.Dict;
 
 /** Specialization of a DictLiteralInstruction which always returns an empty dict
@@ -15,7 +16,7 @@ public class EmptyDictLiteralInstruction extends DictLiteralInstruction {
 	public static final EmptyDictLiteralInstruction INSTANCE = new EmptyDictLiteralInstruction();
 	
 	protected EmptyDictLiteralInstruction() {
-		super(null, new Block());
+		super(null, StaticBlock.EMPTY);
 	}
 	
 	@Override

--- a/src/aya/instruction/EmptyDictLiteralInstruction.java
+++ b/src/aya/instruction/EmptyDictLiteralInstruction.java
@@ -3,7 +3,6 @@ package aya.instruction;
 import java.util.Queue;
 
 import aya.obj.Obj;
-import aya.obj.block.Block;
 import aya.obj.block.StaticBlock;
 import aya.obj.dict.Dict;
 

--- a/src/aya/instruction/InterpolateStringInstruction.java
+++ b/src/aya/instruction/InterpolateStringInstruction.java
@@ -42,7 +42,8 @@ public class InterpolateStringInstruction extends Instruction  {
 			} else if (current instanceof DataInstruction) {
 				Obj data = ((DataInstruction)current).getData();
 				if (data.isa(Obj.BLOCK)) {
-					Block b = new Block(Casting.asStaticBlock(data));
+					Block b = new Block();
+					b.dump(Casting.asStaticBlock(data));
 					b.eval();
 					if (b.getStack().size() == 1) {
 						sb.append(b.getStack().pop().str());

--- a/src/aya/instruction/InterpolateStringInstruction.java
+++ b/src/aya/instruction/InterpolateStringInstruction.java
@@ -8,6 +8,7 @@ import aya.obj.Obj;
 import aya.obj.block.Block;
 import aya.obj.list.List;
 import aya.parser.SourceStringRef;
+import aya.util.Casting;
 
 public class InterpolateStringInstruction extends Instruction  {
 	String orig; // For printing
@@ -41,7 +42,7 @@ public class InterpolateStringInstruction extends Instruction  {
 			} else if (current instanceof DataInstruction) {
 				Obj data = ((DataInstruction)current).getData();
 				if (data.isa(Obj.BLOCK)) {
-					Block b = ((Block)data).duplicate();
+					Block b = new Block(Casting.asStaticBlock(data));
 					b.eval();
 					if (b.getStack().size() == 1) {
 						sb.append(b.getStack().pop().str());

--- a/src/aya/instruction/ListBuilderInstruction.java
+++ b/src/aya/instruction/ListBuilderInstruction.java
@@ -30,7 +30,8 @@ public class ListBuilderInstruction extends Instruction {
 	}
 	
 	public List createList(Stack<Obj> outerStack) {
-		Block evaluator = new Block(initialList);
+		Block evaluator = new Block();
+		evaluator.dump(initialList);
 
 		for (int p = 0; p < num_captures; p++) {
 			evaluator.add(outerStack.pop());

--- a/src/aya/instruction/TupleInstruction.java
+++ b/src/aya/instruction/TupleInstruction.java
@@ -7,16 +7,18 @@ import aya.ReprStream;
 import aya.exceptions.runtime.EmptyStackError;
 import aya.obj.Obj;
 import aya.obj.block.Block;
+import aya.obj.block.BlockUtils;
+import aya.obj.block.StaticBlock;
 import aya.parser.SourceStringRef;
 
 public class TupleInstruction extends Instruction {	
-	Block[] elements;
+	StaticBlock[] elements;
 	
 	/** 
 	 * Tuples will not need to be resized during runtime
 	 * @param blocks
 	 */
-	public TupleInstruction(SourceStringRef source, Block[] blocks) {
+	public TupleInstruction(SourceStringRef source, StaticBlock[] blocks) {
 		super(source);
 		elements = blocks;
 	}
@@ -29,15 +31,15 @@ public class TupleInstruction extends Instruction {
 	public ArrayList<Obj> evalToResults() {
 		ArrayList<Obj> out = new ArrayList<Obj>(elements.length);
 		for (int i = 0; i < elements.length; i++) {
-			Block b = elements[i].duplicate();
+			Block evaluator = new Block(elements[i]);
 			try {
-				b.eval();
+				evaluator.eval();
 			} catch (EmptyStackException e) {
 				EmptyStackError e2 = new EmptyStackError("Empty stack during evaluation of tuple");
 				e2.setSource(this.getSource());
 				throw e2;
 			}
-			out.add(b.pop());
+			out.add(evaluator.pop());
 		}
 		return out;
 	}
@@ -54,7 +56,7 @@ public class TupleInstruction extends Instruction {
 			if(i!=0) {
 				stream.print(", ");
 			}
-			elements[i].repr(stream, false);
+			BlockUtils.repr(stream, elements[i], false);
 		}
 		stream.print(")");
 		return stream;

--- a/src/aya/instruction/TupleInstruction.java
+++ b/src/aya/instruction/TupleInstruction.java
@@ -31,7 +31,8 @@ public class TupleInstruction extends Instruction {
 	public ArrayList<Obj> evalToResults() {
 		ArrayList<Obj> out = new ArrayList<Obj>(elements.length);
 		for (int i = 0; i < elements.length; i++) {
-			Block evaluator = new Block(elements[i]);
+			Block evaluator = new Block();
+			evaluator.dump(elements[i]);
 			try {
 				evaluator.eval();
 			} catch (EmptyStackException e) {

--- a/src/aya/instruction/index/GetExprIndexInstruction.java
+++ b/src/aya/instruction/index/GetExprIndexInstruction.java
@@ -26,7 +26,8 @@ public class GetExprIndexInstruction extends GetIndexInstruction {
 	}
 	
 	protected Obj getIndex() {
-		Block evaluator = new Block(_index);
+		Block evaluator = new Block();
+		evaluator.dump(_index);
 		evaluator.eval();
 		if (evaluator.getStack().size() == 1) {
 			return evaluator.getStack().pop();

--- a/src/aya/instruction/index/GetExprIndexInstruction.java
+++ b/src/aya/instruction/index/GetExprIndexInstruction.java
@@ -4,13 +4,15 @@ import aya.ReprStream;
 import aya.exceptions.runtime.ValueError;
 import aya.obj.Obj;
 import aya.obj.block.Block;
+import aya.obj.block.BlockUtils;
+import aya.obj.block.StaticBlock;
 import aya.parser.SourceStringRef;
 
 public class GetExprIndexInstruction extends GetIndexInstruction {
 	
-	private Block _index;
+	private StaticBlock _index;
 
-	public GetExprIndexInstruction(SourceStringRef source, Block index) {
+	public GetExprIndexInstruction(SourceStringRef source, StaticBlock index) {
 		super(source);
 		_index = index;
 	}
@@ -18,17 +20,17 @@ public class GetExprIndexInstruction extends GetIndexInstruction {
 	@Override
 	public ReprStream repr(ReprStream stream) {
 		stream.print(".[");
-		_index.repr(stream, false);
+		BlockUtils.repr(stream, _index, false, null);
 		stream.print("]");
 		return stream;
 	}
 	
 	protected Obj getIndex() {
-		Block index = _index.duplicate();
-		index.eval();
-		if (index.getStack().size() == 1) {
-			return index.getStack().pop();
-		} else if (index.getStack().size() > 1) {
+		Block evaluator = new Block(_index);
+		evaluator.eval();
+		if (evaluator.getStack().size() == 1) {
+			return evaluator.getStack().pop();
+		} else if (evaluator.getStack().size() > 1) {
 			throw new ValueError("Error attempting to index object with " + _index.repr() 
 										  + ". Expression returned more than one item");
 		} else {

--- a/src/aya/instruction/index/SetExprIndexInstruction.java
+++ b/src/aya/instruction/index/SetExprIndexInstruction.java
@@ -16,7 +16,8 @@ public class SetExprIndexInstruction extends SetIndexInstruction {
 	}
 	
 	protected Obj getIndex() {
-		Block index = new Block(_index);
+		Block index = new Block();
+		index.dump(_index);
 		index.eval();
 		if (index.getStack().size() == 1) {
 			return index.getStack().pop();

--- a/src/aya/instruction/index/SetExprIndexInstruction.java
+++ b/src/aya/instruction/index/SetExprIndexInstruction.java
@@ -3,19 +3,20 @@ package aya.instruction.index;
 import aya.exceptions.runtime.ValueError;
 import aya.obj.Obj;
 import aya.obj.block.Block;
+import aya.obj.block.StaticBlock;
 import aya.parser.SourceStringRef;
 
 public class SetExprIndexInstruction extends SetIndexInstruction {
 	
-	Block _index;
+	StaticBlock _index;
 	
-	public SetExprIndexInstruction(SourceStringRef source, Block index) {
+	public SetExprIndexInstruction(SourceStringRef source, StaticBlock index) {
 		super(source);
 		_index = index;
 	}
 	
 	protected Obj getIndex() {
-		Block index = _index.duplicate();
+		Block index = new Block(_index);
 		index.eval();
 		if (index.getStack().size() == 1) {
 			return index.getStack().pop();

--- a/src/aya/instruction/op/ColonOps.java
+++ b/src/aya/instruction/op/ColonOps.java
@@ -880,7 +880,7 @@ class OP_Colon_M extends Operator {
 	public OP_Colon_M() {
 		init(":M");
 		arg("DD", "set D1's meta to D2 leave D1 on stack");
-		arg("BD", "duplicate block with the given metadata");
+		arg("BD", "update a copy of the block locals with the dict");
 	}
 
 	@Override
@@ -891,6 +891,9 @@ class OP_Colon_M extends Operator {
 		if(obj.isa(DICT) && meta.isa(DICT)) {
 			((Dict)obj).setMetaTable((Dict)meta);
 			block.push(obj);
+		} else if(obj.isa(BLOCK) && meta.isa(DICT)) {
+			StaticBlock new_block = BlockUtils.mergeLocals(Casting.asStaticBlock(obj), asDict(meta));
+			block.push(new_block);
 		} else {
 			throw new TypeError(this, meta, obj);
 		}
@@ -947,9 +950,10 @@ class OP_Colon_O extends Operator {
 			if ((res = VectorizedFunctions.vectorize2arg(this, a, b)) != null) {
 				return res;
 			} else {
-				Block blk = new Block(_block);
+				Block blk = new Block();
 				blk.push(a);
 				blk.push(b);
+				blk.dump(_block);
 				blk.eval();
 				return blk.pop();
 			}

--- a/src/aya/instruction/op/ColonOps.java
+++ b/src/aya/instruction/op/ColonOps.java
@@ -19,7 +19,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 
 import aya.Aya;
-import aya.ReprStream;
 import aya.exceptions.parser.NotAnOperatorError;
 import aya.exceptions.parser.ParserException;
 import aya.exceptions.runtime.AssertError;
@@ -29,11 +28,11 @@ import aya.exceptions.runtime.MathError;
 import aya.exceptions.runtime.TypeError;
 import aya.exceptions.runtime.UnimplementedError;
 import aya.exceptions.runtime.ValueError;
-import aya.instruction.BlockLiteralInstruction;
-import aya.instruction.Instruction;
-import aya.instruction.variable.VariableInstruction;
 import aya.obj.Obj;
 import aya.obj.block.Block;
+import aya.obj.block.BlockUtils;
+import aya.obj.block.ConditionalUtils;
+import aya.obj.block.StaticBlock;
 import aya.obj.character.Char;
 import aya.obj.dict.Dict;
 import aya.obj.list.List;
@@ -384,7 +383,7 @@ class OP_Colon_Times extends Operator {
 		Obj a  = block.pop();
 		
 		if (c.isa(BLOCK)) {
-			Block expr = (Block)c;
+			StaticBlock expr = Casting.asStaticBlock(c);
 			if (b.isa(LIST) && a.isa(LIST)) {
 				List l1 = asList(b);
 				List l2 = asList(a);
@@ -398,9 +397,9 @@ class OP_Colon_Times extends Operator {
 			} else if (b.isa(LIST)) {
 				block.push(asList(b).map1arg(expr, a));
 			} else if (a.isa(LIST)) {
-				Block e = new Block();
-				e.addAll(expr.getInstructions().getInstrucionList());
-				e.add(b);
+				StaticBlock e = StaticBlock.EMPTY;
+				e = BlockUtils.addAll(e, expr);
+				e = BlockUtils.add(e, b);
 				block.push(asList(a).map(e));
 			} else {
 				throw new TypeError(this, c, b, a);
@@ -545,61 +544,19 @@ class OP_Colon_Bool extends Operator {
 	
 	public OP_Colon_Bool() {
 		init(":?");
-		arg("A", "convert to boolean");
+		arg("A", "if/else");
 	}
 
 	@Override
 	public void execute (Block block) {		
 		Obj a = block.pop();
 		if (a.isa(Obj.BLOCK)) {
-			Obj result = runConditional(Casting.asBlock(a).getInstructions().getInstrucionList());
+			Obj result = ConditionalUtils.runConditional(Casting.asStaticBlock(a));
 			if (result != null) {
 				block.push(result);
 			}
 		} else {
 			throw new TypeError(this, a);
-		}
-	}
-	
-	private static boolean evalCondition(Instruction instruction) {
-		Block b = new Block();
-		b.add(instruction);
-		b.eval();
-		if (!b.getStack().isEmpty()) {
-			return b.pop().bool();
-		} else {
-			ReprStream rs = new ReprStream();
-			instruction.repr(rs);
-			throw new TypeError("Condition did not return a result: " + rs.toString());
-		}
-	}
-	
-	private static Obj evalResult(Instruction instruction) {
-		Block b = new Block();
-		if (instruction instanceof BlockLiteralInstruction) {
-			b.addAll(((BlockLiteralInstruction)instruction).getBlock().getInstructions().getInstrucionList());
-		} else {
-			b.add(instruction);
-		}
-		b.eval();
-		if (!b.getStack().isEmpty()) {
-			return b.pop();
-		} else {
-			return null;
-		}
-	}
-	
-	private static Obj runConditional(ArrayList<Instruction> instructions) {
-		int i;
-		for (i = instructions.size()-1; i > 0; i-=2) {
-			if (evalCondition(instructions.get(i))) {
-				return evalResult(instructions.get(i-1));
-			}
-		}
-		if (i == 0) {
-			return evalResult(instructions.get(i));
-		} else {
-			return null;
 		}
 	}
 }
@@ -973,9 +930,9 @@ class OP_Colon_O extends Operator {
 		arg("AAB", "apply (2-arg)");
 	}
 
-	private class BlockOpInstruction extends Operator {
-		private final Block _block;
-		public BlockOpInstruction(Block block) {
+	private static class BlockOpInstruction extends Operator {
+		private final StaticBlock _block;
+		public BlockOpInstruction(StaticBlock block) {
 			_block = block;
 		}
 		@Override
@@ -990,7 +947,7 @@ class OP_Colon_O extends Operator {
 			if ((res = VectorizedFunctions.vectorize2arg(this, a, b)) != null) {
 				return res;
 			} else {
-				Block blk = _block.duplicate();
+				Block blk = new Block(_block);
 				blk.push(a);
 				blk.push(b);
 				blk.eval();
@@ -1007,7 +964,7 @@ class OP_Colon_O extends Operator {
 		final Obj a = block.pop();
 
 		if (c.isa(Obj.BLOCK)) {
-			final BlockOpInstruction block_op = new BlockOpInstruction(Casting.asBlock(c));
+			final BlockOpInstruction block_op = new BlockOpInstruction(Casting.asStaticBlock(c));
 			block.push(VectorizedFunctions.vectorize2arg(block_op, a, b));
 		} else {
 			throw new TypeError(this, c, b, a);
@@ -1065,28 +1022,12 @@ class OP_Colon_S extends Operator {
 		if (a.isa(STR) || a.isa(CHAR)) {
 			block.push(Aya.getInstance().getSymbols().getSymbol(a.str()));
 		} else if (a.isa(BLOCK)) {
-			block.push(singleToSymbolList((Block)a));
+			block.push(BlockUtils.singleToSymbolList(Casting.asStaticBlock(a)));
 		} else {
 			throw new TypeError(this, a);
 		}
 	}
 
-	private List singleToSymbolList(Block b) {
-		ArrayList<Obj> out = new ArrayList<Obj>();
-		ArrayList<Instruction> instructions = b.getInstructions().getInstrucionList();
-		if (instructions.size() == 1) {
-			Instruction i = instructions.get(0);
-			if (i instanceof VariableInstruction) {
-				out.add( ((VariableInstruction)i).getSymbol() );
-			} else if (i instanceof OperatorInstruction) {
-				Operator op = ((OperatorInstruction)i).getOperator();
-				if (op.overload() != null) {
-					out.addAll(op.overload().getSymbols());
-				}
-			}
-		}
-		return new List(out);
-	}
 }
 
 
@@ -1189,8 +1130,7 @@ class OP_Colon_Tick extends Operator {
 			}
 			List l = new List();
 			for (int i = 0; i < n; i++) {
-				final Block b = new Block();
-				b.add(block.getInstructions().popNextNonFlagInstruction());
+				StaticBlock b = BlockUtils.makeBlockWithSingleInstruction(block.getInstructions().popNextNonFlagInstruction());
 				l.mutAdd(b);
 			}
 			if (unwrap_list) {
@@ -1199,7 +1139,7 @@ class OP_Colon_Tick extends Operator {
 				block.push(l);
 			}
 			
-			block.addAll(Casting.asBlock(blk_obj).getInstructions().getInstrucionList());
+			block.dump(Casting.asStaticBlock(blk_obj));
 			
 		} else {
 			throw new TypeError(this, n_obj, blk_obj);

--- a/src/aya/instruction/op/DotOps.java
+++ b/src/aya/instruction/op/DotOps.java
@@ -498,7 +498,7 @@ class OP_Dot_Plus extends Operator {
 			StaticBlock blk = asStaticBlock(b);
 			// Constant capture from dict
 			if (a.isa(DICT)) {
-				Dict.assignVarValues((Dict)a, blk);
+				blk = BlockUtils.assignVarValues(Casting.asDict(a), blk);
 			}
 			// Constant capture from scope
 			else if (a.isa(SYMBOL)) {

--- a/src/aya/instruction/op/DotOps.java
+++ b/src/aya/instruction/op/DotOps.java
@@ -41,7 +41,6 @@ import aya.exceptions.runtime.UserObjRuntimeException;
 import aya.exceptions.runtime.ValueError;
 import aya.ext.dialog.QuickDialog;
 import aya.instruction.DataInstruction;
-import aya.instruction.Instruction;
 import aya.instruction.ListBuilderInstruction;
 import aya.obj.Obj;
 import aya.obj.block.Block;
@@ -381,7 +380,7 @@ class OP_Dot_And extends Operator {
 		} else if ( c.isa(STR) && (a.isa(STR) || a.isa(CHAR)) && (b.isa(STR) || b.isa(CHAR))) {
 			block.push(List.fromString( c.str().replaceAll(b.str(), a.str()) ));
 		} else if (a.isa(BLOCK) && b.isa(LIST) && c.isa(LIST)) {
-			StaticBlock initial = new StaticBlock(new ArrayList<Instruction>());
+			StaticBlock initial = StaticBlock.EMPTY;
 			BlockUtils.addObjToStack(initial, c);
 			BlockUtils.addObjToStack(initial, b);
 			ListBuilderInstruction lb = new ListBuilderInstruction(null, initial, asStaticBlock(a), null, 0);

--- a/src/aya/instruction/op/DotOps.java
+++ b/src/aya/instruction/op/DotOps.java
@@ -380,10 +380,10 @@ class OP_Dot_And extends Operator {
 		} else if ( c.isa(STR) && (a.isa(STR) || a.isa(CHAR)) && (b.isa(STR) || b.isa(CHAR))) {
 			block.push(List.fromString( c.str().replaceAll(b.str(), a.str()) ));
 		} else if (a.isa(BLOCK) && b.isa(LIST) && c.isa(LIST)) {
-			StaticBlock initial = StaticBlock.EMPTY;
-			BlockUtils.addObjToStack(initial, c);
-			BlockUtils.addObjToStack(initial, b);
-			ListBuilderInstruction lb = new ListBuilderInstruction(null, initial, asStaticBlock(a), null, 0);
+			StaticBlock zip_block = StaticBlock.EMPTY;
+			zip_block = BlockUtils.addObjToStack(zip_block, b);
+			zip_block = BlockUtils.addObjToStack(zip_block, c);
+			ListBuilderInstruction lb = new ListBuilderInstruction(null, zip_block, asStaticBlock(a), null, 0);
 			block.add(lb);
 		} else {
 			throw new TypeError(this,a,b,c);
@@ -1077,9 +1077,10 @@ class OP_Dot_TryCatch extends Operator {
 
 		if(tryBlock.isa(BLOCK) && catchBlock.isa(BLOCK)) {
 			try {
-				Block evaluator = new Block(asStaticBlock(tryBlock));
+				Block evaluator = new Block();
 				Aya.getInstance().getCallStack().setCheckpoint();
 				Aya.getInstance().getVars().setCheckpoint();
+				evaluator.dump(asStaticBlock(tryBlock));
 				evaluator.eval();
 				Aya.getInstance().getCallStack().popCheckpoint();
 				Aya.getInstance().getVars().popCheckpoint();
@@ -1087,8 +1088,9 @@ class OP_Dot_TryCatch extends Operator {
 			} catch (AyaRuntimeException e) {
 				Aya.getInstance().getCallStack().rollbackCheckpoint();
 				Aya.getInstance().getVars().rollbackCheckpoint();
-				Block evaluator = new Block(asStaticBlock(catchBlock));
+				Block evaluator = new Block();
 				evaluator.push(e.getDict());
+				evaluator.dump(asStaticBlock(catchBlock));
 				evaluator.eval();
 				block.appendToStack(evaluator.getStack());
 			} catch (Exception e2) {
@@ -1143,8 +1145,9 @@ class OP_Dot_N extends Operator {
 			final StaticBlock blk = asStaticBlock(a);
 			List l = asList(b);
 			for (int i = 0; i < l.length(); i++) {
-				Block cond = new Block(blk);
+				Block cond = new Block();
 				cond.push(l.getExact(i));
+				cond.dump(blk);
 				cond.eval();
 				Obj result = cond.pop();
 				if (result.bool()) {
@@ -1181,8 +1184,9 @@ class OP_Dot_O extends Operator {
 		if ((res = VectorizedFunctions.vectorize2arg(this, a, b)) != null) return res;
 		
 		if (b.isa(BLOCK)) {
-			Block blk = new Block(asStaticBlock(b));
+			Block blk = new Block();
 			blk.push(a);
+			blk.dump(asStaticBlock(b));
 			blk.eval();
 			return blk.pop();
 		} else {

--- a/src/aya/instruction/op/MiscOps.java
+++ b/src/aya/instruction/op/MiscOps.java
@@ -15,10 +15,9 @@ import aya.exceptions.parser.NotAnOperatorError;
 import aya.exceptions.runtime.TypeError;
 import aya.exceptions.runtime.UnimplementedError;
 import aya.exceptions.runtime.ValueError;
-import aya.instruction.Instruction;
-import aya.instruction.InstructionStack;
 import aya.obj.Obj;
 import aya.obj.block.Block;
+import aya.obj.block.BlockUtils;
 import aya.obj.character.Char;
 import aya.obj.dict.Dict;
 import aya.obj.list.List;
@@ -269,18 +268,7 @@ class OP_Help extends Operator {
 		} else if (s.isa(NUMBER)) {
 			block.push(new List(OpDocReader.getAllOpDicts()));
 		} else if (s.isa(BLOCK)) {
-			InstructionStack instructions = ((Block)s).getInstructions();
-			if (instructions.isEmpty()) {
-				throw new ValueError("Empty block");
-			} else {
-				Instruction i = instructions.pop();
-				if (i instanceof OperatorInstruction) {
-					Operator op = ((OperatorInstruction)i).getOperator();
-					block.push(op.getDoc().toDict());
-				} else {
-					throw new ValueError("No doc found for " + s.str());
-				}
-			}
+			block.push(BlockUtils.getHelpDataForOperator(Casting.asStaticBlock(s)));
 		}
 		else {
 			throw new TypeError(this, s);
@@ -501,8 +489,7 @@ class OP_Mb extends Operator {
 		if (a.isa(Obj.SYMBOL)) {
 			block.push(Num.fromBool(Aya.getInstance().getVars().isDefined(Casting.asSymbol(a))));
 		} else if (a.isa(BLOCK)) {
-			Block b = (Block)a;
-			block.push(b.duplicateAddLocals());
+			block.push(BlockUtils.addLocals(Casting.asStaticBlock(a)));
 		} else {
 			throw new TypeError(this, a);
 		}

--- a/src/aya/instruction/op/Operator.java
+++ b/src/aya/instruction/op/Operator.java
@@ -10,6 +10,8 @@ import aya.instruction.op.overload.OpOverload2Arg;
 import aya.instruction.op.overload.OpOverloadNoOp;
 import aya.obj.Obj;
 import aya.obj.block.Block;
+import aya.obj.block.BlockUtils;
+import aya.obj.block.StaticBlock;
 import aya.obj.dict.Dict;
 import aya.obj.list.List;
 import aya.obj.symbol.SymbolConstants;
@@ -98,9 +100,7 @@ public abstract class Operator {
 		Dict info = new Dict();
 
 		// {op}:call
-		Block call = new Block();
-		// TODO Source
-		call.add(new OperatorInstruction(null, this));
+		StaticBlock call = BlockUtils.makeBlockWithSingleInstruction(new OperatorInstruction(null, this));
 		info.set(SymbolConstants.CALL, call);
 		
 		// [::sym]:symbols;

--- a/src/aya/instruction/variable/GetKeyVariableInstruction.java
+++ b/src/aya/instruction/variable/GetKeyVariableInstruction.java
@@ -28,7 +28,7 @@ public class GetKeyVariableInstruction extends GetVariableInstruction {
 			if (o.isa(Obj.BLOCK)) {
 				// If user object function, leave it as the first item on the stack
 				if (dict.pushSelf()) b.push(dict);
-				dumpBlock(Casting.asBlock(o), b);
+				dumpBlock(Casting.asStaticBlock(o), b);
 			} else {
 				b.push(o);
 			}

--- a/src/aya/instruction/variable/GetVariableInstruction.java
+++ b/src/aya/instruction/variable/GetVariableInstruction.java
@@ -5,6 +5,7 @@ import aya.ReprStream;
 import aya.instruction.flag.PopCallstackInstruction;
 import aya.obj.Obj;
 import aya.obj.block.Block;
+import aya.obj.block.StaticBlock;
 import aya.obj.symbol.Symbol;
 import aya.parser.SourceStringRef;
 import aya.util.Casting;
@@ -28,16 +29,17 @@ public class GetVariableInstruction extends VariableInstruction {
 	 */
 	public void addOrDumpVar(Obj o, Block b) {
 		if (o.isa(Obj.BLOCK)) {
-			dumpBlock(Casting.asBlock(o), b);
+			dumpBlock(Casting.asStaticBlock(o), b);
 		} else {
 			b.push(o);
 		}
 	}
 
-	public void dumpBlock(Block block_to_dump, Block b) {
+	public void dumpBlock(StaticBlock block_to_dump, Block evaluator) {
 		Aya.getInstance().getCallStack().push(this);
-		b.add(PopCallstackInstruction.INSTANCE);
-		b.getInstructions().addAll(block_to_dump.getInstructions().getInstrucionList());
+		evaluator.add(PopCallstackInstruction.INSTANCE);
+		//b.getInstructions().addAll(block_to_dump.getInstructions().getInstrucionList());
+		evaluator.dump(block_to_dump);
 	}
 
 	@Override

--- a/src/aya/instruction/variable/QuoteGetVariableInstruction.java
+++ b/src/aya/instruction/variable/QuoteGetVariableInstruction.java
@@ -6,6 +6,7 @@ import aya.obj.Obj;
 import aya.obj.block.Block;
 import aya.obj.symbol.Symbol;
 import aya.parser.SourceStringRef;
+import aya.util.Casting;
 
 public class QuoteGetVariableInstruction extends VariableInstruction {
 
@@ -24,11 +25,12 @@ public class QuoteGetVariableInstruction extends VariableInstruction {
 	 * @param o
 	 * @param b
 	 */
-	public static void addOrDumpVar(Obj o, Block b) {
+	public static void addOrDumpVar(Obj o, Block evaluator) {
 		if (o.isa(Obj.BLOCK)) {
-			b.getInstructions().addAll(((Block)o).getInstructions().getInstrucionList());
+			//evaluator.getInstructions().addAll(((Block)o).getInstructions().getInstrucionList());
+			evaluator.dump(Casting.asStaticBlock(o));
 		} else {
-			b.push(o);
+			evaluator.push(o);
 		}
 	}
 	

--- a/src/aya/obj/block/Block.java
+++ b/src/aya/obj/block/Block.java
@@ -259,7 +259,6 @@ public class Block {
 	/** Adds an item to the back of the instruction stack. (opposite of add()) */
 	public void addBack(Obj b) {
 		instructions.insert(0, new DataInstruction(b));
-		
 	}
 	
 	/** Adds a stack to this block. Reverses the stack before adding */

--- a/src/aya/obj/block/Block.java
+++ b/src/aya/obj/block/Block.java
@@ -143,7 +143,10 @@ public class Block extends Obj {
 		return flag instanceof PopVarFlagInstruction;
 	}
 	
-
+	public void dump(StaticBlock block) {
+		block.dumpToBlockEvaluator(this);
+	}
+	
 	/** Evaluates each instruction in the instruction stack and places the result in the output stack */ 
 	public void eval() {
 		while (!instructions.isEmpty()) {

--- a/src/aya/obj/block/Block.java
+++ b/src/aya/obj/block/Block.java
@@ -43,11 +43,6 @@ public class Block {
 		this.instructions = il;
 	}
 	
-	public Block(StaticBlock b) {
-		this();
-		this.dump(b);
-	}
-
 	/** Returns the output stack */
 	public Stack<Obj> getStack() {
 		return this.stack;
@@ -162,8 +157,9 @@ public class Block {
 				EmptyStackError es2 = new EmptyStackError("Unexpected empty stack while executing instruction: " + instr);
 				es2.setSource(instr.getSource());
 				throw es2;
-			} catch (NullPointerException npe) {
-				throw new RuntimeException(npe);
+			//}// catch (NullPointerException npe) {
+			//	throw npe;
+			//	throw new RuntimeException(npe);
 			} catch (AyaRuntimeException are) {
 				are.setSource(instr.getSource());
 				throw are;

--- a/src/aya/obj/block/Block.java
+++ b/src/aya/obj/block/Block.java
@@ -44,7 +44,7 @@ public class Block {
 	}
 	
 	public Block(StaticBlock b) {
-		super();
+		this();
 		this.dump(b);
 	}
 

--- a/src/aya/obj/block/BlockHeader.java
+++ b/src/aya/obj/block/BlockHeader.java
@@ -63,6 +63,8 @@ public class BlockHeader extends Instruction {
 	}
 	
 	public ReprStream repr(ReprStream stream, HashMap<Symbol, Block> defaults) {
+		return stream;
+		/*
 		for (int i = _args.size()-1; i >= 0; i--) {
 			stream.print(_args.get(i).toString());
 			stream.print(" ");
@@ -83,7 +85,7 @@ public class BlockHeader extends Instruction {
 		if (defaults != null) {
 			for (Symbol v : defaults.keySet()) {
 				stream.print(v.name() + "(");
-				defaults.get(v).repr(stream, false);
+				BlockUtils.repr(stream, defaults.get(v), false, null);
 				stream.print(") ");
 			}
 		}
@@ -92,6 +94,7 @@ public class BlockHeader extends Instruction {
 		stream.delTrailingSpaces();
 		stream.print(",");
 		return stream;
+		*/
 	}
 
 	/**

--- a/src/aya/obj/block/BlockUtils.java
+++ b/src/aya/obj/block/BlockUtils.java
@@ -1,16 +1,28 @@
 package aya.obj.block;
 
 import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 
+import aya.Aya;
 import aya.ReprStream;
+import aya.exceptions.runtime.ValueError;
+import aya.instruction.DataInstruction;
 import aya.instruction.Instruction;
 import aya.instruction.InstructionStack;
+import aya.instruction.op.Operator;
+import aya.instruction.op.OperatorInstruction;
+import aya.instruction.variable.GetVariableInstruction;
+import aya.instruction.variable.VariableInstruction;
 import aya.instruction.variable.assignment.Assignment;
 import aya.obj.Obj;
 import aya.obj.dict.Dict;
 import aya.obj.list.List;
 import aya.obj.symbol.Symbol;
+import aya.obj.symbol.SymbolConstants;
+import aya.util.Casting;
+import aya.util.Pair;
 
 public class BlockUtils {
 
@@ -34,8 +46,17 @@ public class BlockUtils {
 		}
 	}
 	
+	// Always returns a Dict
+	public static Dict copyLocals(StaticBlock b) {
+		if (b.getLocals() == null) {
+			return new Dict();
+		} else {
+			return b.getLocals().clone();
+		}
+	}
+	
 	public static StaticBlock mergeLocals(StaticBlock block, Dict locals) {
-		Dict new_locals = block.getLocals().clone();
+		Dict new_locals = copyLocals(block);
 		new_locals.update(locals);
 		return new StaticBlock(block.getInstructions(), new_locals, block.getArgs());
 	}
@@ -121,5 +142,155 @@ public class BlockUtils {
 	
 	public static StaticBlock fromIS(InstructionStack is) {
 		return new StaticBlock(is.getInstrucionList());
+	}
+	
+	public static StaticBlock stripHeader(StaticBlock block) {
+		return new StaticBlock(block.getInstructions());
+	}
+	
+	// Not optimized, should refactor later
+	public static StaticBlock addObjToStack(StaticBlock block, Obj o) {
+		ArrayList<Instruction> is = new ArrayList<Instruction>();
+		is.add(new DataInstruction(o));
+		is.addAll(block.getInstructions());
+		return replaceInstructions(block, is);
+	}
+	
+	private static StaticBlock replaceInstructions(StaticBlock block, ArrayList<Instruction> is) {
+		return new StaticBlock(is, block.getLocals(), block.getArgs());
+	}
+
+
+	public static StaticBlock assignVarValues(Dict d, StaticBlock blk) {
+		ArrayList<Instruction> new_is = new ArrayList<Instruction>();
+		Collections.copy(blk.getInstructions(), new_is);
+
+		for (Pair<Symbol, Obj> pair : d.items()) {
+			Symbol var = pair.first();
+			Obj item = pair.second();
+
+			// Finds all vars with id matching varid and swaps them with item
+			for (int i = 0; i < new_is.size(); i++) {
+				final Instruction o = new_is.get(i);
+				if (o instanceof GetVariableInstruction && ((GetVariableInstruction)o).getSymbol().id() == var.id()) {
+					new_is.set(i, new DataInstruction(item));
+				}
+			}
+		}
+		
+		return replaceInstructions(blk, new_is);
+	}
+
+	public static Dict getBlockMeta(StaticBlock b) {
+		Dict d = new Dict();
+
+		ArrayList<Obj> args_list = new ArrayList<Obj>();
+		for (Assignment a : b.getArgs()) {
+			args_list.add(a.toDict());
+		}
+		Collections.reverse(args_list);
+		d.set(SymbolConstants.ARGS, new List(args_list));
+		final Dict vars = copyLocals(b);
+		if (vars != null) {
+			d.set(SymbolConstants.LOCALS, vars);
+		}
+				
+		return d;
+	}
+	
+	// If the block has a single variable, convert it to a symbol
+	// otherwise return the block
+	public static Obj convertSingleVariableToSymbol(StaticBlock b) {
+		ArrayList<Instruction> is = b.getInstructions();
+		if (is.size() > 0) {
+			Instruction i = is.get(0);
+			if (i instanceof VariableInstruction) {
+				VariableInstruction v = (VariableInstruction)i;
+				return v.getSymbol();
+			}
+		}
+		// Cannot convert, return original
+		return b;
+	}
+	
+	public static StaticBlock fromList(List l) {
+		ArrayList<Instruction> is = new ArrayList<Instruction>();
+		for (int i = 0; i < l.length(); i++) {
+			final Obj k = l.getExact(i);
+			if (k.isa(Obj.BLOCK)) {
+				for (Instruction j : Casting.asStaticBlock(k).getInstructions()) {
+					is.add(0, j);
+				}
+			} else {
+				is.add(0, new DataInstruction(k));
+			}
+		}
+		return new StaticBlock(is);
+	}
+
+	public static StaticBlock capture(StaticBlock b, Symbol s) {
+		Obj o = Aya.getInstance().getVars().getVar(s);
+		Dict locals = copyLocals(b);
+		locals.set(s, o);
+		return new StaticBlock(b.getInstructions(), locals, b.getArgs());
+	}
+
+	/** Add an object to the instruction stack */
+	public static StaticBlock add(StaticBlock b, Obj o) {
+		ArrayList<Instruction> instructions = b.getInstructions();
+		instructions.add(new DataInstruction(o));
+		return new StaticBlock(instructions, b.getLocals(), b.getArgs());
+	}
+
+	/** Add an instruction to the instruction stack */
+	public static StaticBlock add(StaticBlock b, Instruction o) {
+		ArrayList<Instruction> instructions = b.getInstructions();
+		instructions.add(o);
+		return new StaticBlock(instructions, b.getLocals(), b.getArgs());
+	}
+
+	/** Adds a collection of objects to the instruction stack */
+	public static StaticBlock addAll(StaticBlock b, StaticBlock toAdd) {
+		ArrayList<Instruction> instructions = b.getInstructions();
+		instructions.addAll(toAdd.getInstructions());
+		return new StaticBlock(instructions, b.getLocals(), b.getArgs());
+	}
+	
+	/** Adds a collection of objects to the instruction stack */
+	public static StaticBlock addAll(StaticBlock b, Collection<? extends Instruction> list) {
+		ArrayList<Instruction> instructions = b.getInstructions();
+		instructions.addAll(list);
+		return new StaticBlock(instructions, b.getLocals(), b.getArgs());
+	}
+
+	public static List singleToSymbolList(StaticBlock b) {
+		ArrayList<Obj> out = new ArrayList<Obj>();
+		ArrayList<Instruction> instructions = b.getInstructions();
+		if (instructions.size() == 1) {
+			Instruction i = instructions.get(0);
+			if (i instanceof VariableInstruction) {
+				out.add( ((VariableInstruction)i).getSymbol() );
+			} else if (i instanceof OperatorInstruction) {
+				Operator op = ((OperatorInstruction)i).getOperator();
+				if (op.overload() != null) {
+					out.addAll(op.overload().getSymbols());
+				}
+			}
+		}
+		return new List(out);
+	}
+
+	public static Dict getHelpDataForOperator(StaticBlock block) {
+		if (block.getInstructions().size() == 0) {
+			throw new ValueError("Empty block");
+		} else {
+			Instruction i = block.getInstructions().get(0);
+			if (i instanceof OperatorInstruction) {
+				Operator op = ((OperatorInstruction)i).getOperator();
+				return op.getDoc().toDict();
+			} else {
+				throw new ValueError("No doc found for " + block.str());
+			}
+		}
 	}
 }

--- a/src/aya/obj/block/BlockUtils.java
+++ b/src/aya/obj/block/BlockUtils.java
@@ -2,7 +2,6 @@ package aya.obj.block;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 
 import aya.Aya;
@@ -164,8 +163,8 @@ public class BlockUtils {
 	// Not optimized, should refactor later
 	public static StaticBlock addObjToStack(StaticBlock block, Obj o) {
 		ArrayList<Instruction> is = new ArrayList<Instruction>();
-		is.add(new DataInstruction(o));
 		is.addAll(block.getInstructions());
+		is.add(new DataInstruction(o));
 		return replaceInstructions(block, is);
 	}
 	
@@ -175,8 +174,7 @@ public class BlockUtils {
 
 
 	public static StaticBlock assignVarValues(Dict d, StaticBlock blk) {
-		ArrayList<Instruction> new_is = new ArrayList<Instruction>();
-		Collections.copy(blk.getInstructions(), new_is);
+		ArrayList<Instruction> new_is = new ArrayList<Instruction>(blk.getInstructions());
 
 		for (Pair<Symbol, Obj> pair : d.items()) {
 			Symbol var = pair.first();

--- a/src/aya/obj/block/BlockUtils.java
+++ b/src/aya/obj/block/BlockUtils.java
@@ -76,8 +76,8 @@ public class BlockUtils {
 			// Header
 			if (locals != null) {
 				// Args
-				for (int i = args.size()-1; i >= 0; i--) {
-					stream.print(args.get(i).toString());
+				for (Assignment arg : args) {
+					stream.print(arg.toString());
 					stream.print(" ");
 				}
 				
@@ -108,9 +108,10 @@ public class BlockUtils {
 				stream.delTrailingSpaces();
 				stream.print(",");
 			}
-
-			for(Instruction i : block.getInstructions()) {
-				i.repr(stream);
+			
+			ArrayList<Instruction> is = block.getInstructions();
+			for(int i = is.size() - 1; i >= 0; i--) {
+				is.get(i).repr(stream);
 				stream.print(" ");
 			}
 
@@ -141,7 +142,17 @@ public class BlockUtils {
 	}
 	
 	public static StaticBlock fromIS(InstructionStack is) {
-		return new StaticBlock(is.getInstrucionList());
+		return fromIS(is, null, null);
+	}
+
+	public static StaticBlock fromIS(InstructionStack is, Dict locals, ArrayList<Assignment> args) {
+		ArrayList<Instruction> instructions = is.getInstrucionList();
+		ArrayList<Instruction> block_instructions = new ArrayList<Instruction>();
+		//for (int i = instructions.size()-1; i >= 0; i--) {
+		//	block_instructions.add(instructions.get(i));
+		//}
+		block_instructions.addAll(instructions); // copy
+		return new StaticBlock(block_instructions, locals, args);
 	}
 	
 	public static StaticBlock stripHeader(StaticBlock block) {
@@ -293,4 +304,5 @@ public class BlockUtils {
 			}
 		}
 	}
+
 }

--- a/src/aya/obj/block/BlockUtils.java
+++ b/src/aya/obj/block/BlockUtils.java
@@ -76,9 +76,11 @@ public class BlockUtils {
 			// Header
 			if (locals != null) {
 				// Args
-				for (Assignment arg : args) {
-					stream.print(arg.toString());
-					stream.print(" ");
+				if (args != null) {
+					for (Assignment arg : args) {
+						stream.print(arg.toString());
+						stream.print(" ");
+					}
 				}
 				
 				// Non-arg locals
@@ -195,12 +197,17 @@ public class BlockUtils {
 	public static Dict getBlockMeta(StaticBlock b) {
 		Dict d = new Dict();
 
-		ArrayList<Obj> args_list = new ArrayList<Obj>();
-		for (Assignment a : b.getArgs()) {
-			args_list.add(a.toDict());
+		ArrayList<Assignment> args = b.getArgs();
+		if (args != null) {
+			ArrayList<Obj> args_list = new ArrayList<Obj>();
+			for (Assignment a : b.getArgs()) {
+				args_list.add(a.toDict());
+			}
+			d.set(SymbolConstants.ARGS, new List(args_list));
+		} else {
+			d.set(SymbolConstants.ARGS, new List());
 		}
-		Collections.reverse(args_list);
-		d.set(SymbolConstants.ARGS, new List(args_list));
+			
 		final Dict vars = copyLocals(b);
 		if (vars != null) {
 			d.set(SymbolConstants.LOCALS, vars);
@@ -229,8 +236,10 @@ public class BlockUtils {
 		for (int i = 0; i < l.length(); i++) {
 			final Obj k = l.getExact(i);
 			if (k.isa(Obj.BLOCK)) {
-				for (Instruction j : Casting.asStaticBlock(k).getInstructions()) {
-					is.add(0, j);
+				// Add these in reverse
+				ArrayList<Instruction> blk_is = Casting.asStaticBlock(k).getInstructions();
+				for (int j = blk_is.size()-1; j >= 0; j--) {
+					is.add(0, blk_is.get(j));
 				}
 			} else {
 				is.add(0, new DataInstruction(k));

--- a/src/aya/obj/block/BlockUtils.java
+++ b/src/aya/obj/block/BlockUtils.java
@@ -5,6 +5,7 @@ import java.util.HashMap;
 
 import aya.ReprStream;
 import aya.instruction.Instruction;
+import aya.instruction.InstructionStack;
 import aya.instruction.variable.assignment.Assignment;
 import aya.obj.Obj;
 import aya.obj.dict.Dict;
@@ -116,5 +117,9 @@ public class BlockUtils {
 		ArrayList<Instruction> is = new ArrayList<Instruction>();
 		is.add(i);
 		return new StaticBlock(is);
+	}
+	
+	public static StaticBlock fromIS(InstructionStack is) {
+		return new StaticBlock(is.getInstrucionList());
 	}
 }

--- a/src/aya/obj/block/BlockUtils.java
+++ b/src/aya/obj/block/BlockUtils.java
@@ -1,0 +1,120 @@
+package aya.obj.block;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+
+import aya.ReprStream;
+import aya.instruction.Instruction;
+import aya.instruction.variable.assignment.Assignment;
+import aya.obj.Obj;
+import aya.obj.dict.Dict;
+import aya.obj.list.List;
+import aya.obj.symbol.Symbol;
+
+public class BlockUtils {
+
+	/** Split a block into a list of blocks, 1 per instruction */
+	public static List split(StaticBlock block) {
+		ArrayList<Obj> blocks = new ArrayList<Obj>();
+		for (Instruction instr : block.getInstructions())
+		{
+			ArrayList<Instruction> is = new ArrayList<Instruction>();
+			is.add(instr);
+			blocks.add(0, new StaticBlock(is));
+		}
+		return new List(blocks);
+	}
+	
+	public static StaticBlock addLocals(StaticBlock block) {
+		if (block.hasLocals()) {
+			return block;
+		} else {
+			return new StaticBlock(block.getInstructions(), new Dict(), block.getArgs());
+		}
+	}
+	
+	public static StaticBlock mergeLocals(StaticBlock block, Dict locals) {
+		Dict new_locals = block.getLocals().clone();
+		new_locals.update(locals);
+		return new StaticBlock(block.getInstructions(), new_locals, block.getArgs());
+	}
+
+	/** If print_braces is true, return "{instructions}" else just "instructions" */
+	public static ReprStream repr(ReprStream stream,
+			               StaticBlock block,
+			               boolean print_braces,
+			               HashMap<Symbol, StaticBlock> defaults) {
+
+		if (stream.visit(block)) {
+			if (print_braces) stream.print("{");
+			
+			Dict locals = block.getLocals();
+			ArrayList<Assignment> args = block.getArgs();
+			
+			// Header
+			if (locals != null) {
+				// Args
+				for (int i = args.size()-1; i >= 0; i--) {
+					stream.print(args.get(i).toString());
+					stream.print(" ");
+				}
+				
+				// Non-arg locals
+				if (locals.size() != 0) {
+					stream.print(": ");
+				
+					// Print locals
+					for (Symbol key : locals.keys()) {
+						stream.print(key.name());
+						stream.print("(");
+						locals.get(key).repr(stream);
+						stream.print(")");
+					}
+				}
+				
+				// Defaults
+				// These are only ever provided if this block is printed from a BlockLiteralInstruction
+				if (defaults != null) {
+					for (Symbol v : defaults.keySet()) {
+						stream.print(v.name() + "(");
+						repr(stream, defaults.get(v), false, null);
+						stream.print(") ");
+					}
+				}
+
+				// Trim off the final space
+				stream.delTrailingSpaces();
+				stream.print(",");
+			}
+
+			for(Instruction i : block.getInstructions()) {
+				i.repr(stream);
+				stream.print(" ");
+			}
+
+			// Remove trailing space
+			stream.delTrailingSpaces();
+
+			if (print_braces) stream.print("}");
+			
+			
+			stream.popVisited(block);
+		} else {
+			stream.print("{...}");
+		}
+
+		return stream;
+	}
+
+	public static ReprStream repr(ReprStream stream,
+			               StaticBlock block,
+			               boolean print_braces) {
+		return repr(stream, block, print_braces, null);
+	}
+	
+	public static StaticBlock makeBlockWithSingleInstruction(Instruction i) {
+		ArrayList<Instruction> is = new ArrayList<Instruction>();
+		is.add(i);
+		return new StaticBlock(is);
+	}
+}

--- a/src/aya/obj/block/ConditionalUtils.java
+++ b/src/aya/obj/block/ConditionalUtils.java
@@ -1,0 +1,55 @@
+package aya.obj.block;
+
+import java.util.ArrayList;
+
+import aya.ReprStream;
+import aya.exceptions.runtime.TypeError;
+import aya.instruction.BlockLiteralInstruction;
+import aya.instruction.Instruction;
+import aya.obj.Obj;
+
+public class ConditionalUtils {
+
+	private static boolean evalCondition(Instruction instruction) {
+		Block b = new Block();
+		b.add(instruction);
+		b.eval();
+		if (!b.getStack().isEmpty()) {
+			return b.pop().bool();
+		} else {
+			ReprStream rs = new ReprStream();
+			instruction.repr(rs);
+			throw new TypeError("Condition did not return a result: " + rs.toString());
+		}
+	}
+	
+	private static Obj evalResult(Instruction instruction) {
+		Block b = new Block();
+		if (instruction instanceof BlockLiteralInstruction) {
+			b.dump(((BlockLiteralInstruction)instruction).getRawBlock());
+		} else {
+			b.add(instruction);
+		}
+		b.eval();
+		if (!b.getStack().isEmpty()) {
+			return b.pop();
+		} else {
+			return null;
+		}
+	}
+	
+	public static Obj runConditional(StaticBlock block) {
+		ArrayList<Instruction> instructions = block.getInstructions();
+		int i;
+		for (i = instructions.size()-1; i > 0; i-=2) {
+			if (evalCondition(instructions.get(i))) {
+				return evalResult(instructions.get(i-1));
+			}
+		}
+		if (i == 0) {
+			return evalResult(instructions.get(i));
+		} else {
+			return null;
+		}
+	}
+}

--- a/src/aya/obj/block/NewLocalsInstruction.java
+++ b/src/aya/obj/block/NewLocalsInstruction.java
@@ -1,0 +1,48 @@
+package aya.obj.block;
+
+import java.util.ArrayList;
+
+import aya.Aya;
+import aya.ReprStream;
+import aya.instruction.Instruction;
+import aya.instruction.variable.assignment.Assignment;
+import aya.obj.dict.Dict;
+
+public class NewLocalsInstruction extends Instruction {
+
+	private Dict _locals;
+	private ArrayList<Assignment> _args;
+	
+		
+	/** This instruction should only be created by dumpToBlockEvaluator */
+	protected NewLocalsInstruction(Dict locals, ArrayList<Assignment> args) {
+		super(null);
+		_locals = locals;
+		_args = args;
+		if (_locals == null) throw new AssertionError();
+
+	}
+	
+	@Override
+	public void execute(Block block) {
+		Dict locals = _locals.clone();
+
+		if (_args != null) {
+			// Assign in reverse order
+			// aya> 1 2 3 {a b c, a b}
+			// 1 2
+			for (int i = _args.size()-1; i >= 0; i--) {
+				_args.get(i).assign(locals, block.pop());
+			}	
+		}
+		
+		// Add a new variable frame to the variable stack
+		Aya.getInstance().getVars().add(locals);
+	}
+
+	@Override
+	public ReprStream repr(ReprStream stream) {
+		return stream;
+	}
+
+}

--- a/src/aya/obj/block/StaticBlock.java
+++ b/src/aya/obj/block/StaticBlock.java
@@ -9,9 +9,10 @@ import aya.instruction.flag.PopVarFlagInstruction;
 import aya.instruction.variable.assignment.Assignment;
 import aya.obj.Obj;
 import aya.obj.dict.Dict;
-import aya.obj.symbol.Symbol;
 
 public class StaticBlock extends Obj {
+	
+	public static StaticBlock EMPTY = new StaticBlock(new ArrayList<Instruction>());
 	
 	private Dict _locals;
 	private ArrayList<Instruction> _instructions;
@@ -30,6 +31,10 @@ public class StaticBlock extends Obj {
 			_locals = new Dict();
 		}
 	}
+
+	public StaticBlock(ArrayList<Instruction> instructions) {
+		this(instructions, null, null);
+	}
 	
 	public void dumpToBlockEvaluator(Block b) {
 		if (_locals != null) {
@@ -46,68 +51,28 @@ public class StaticBlock extends Obj {
 			b.addAll(_instructions);
 		}
 	}
-
-	///////////////////////
-	// String Conversion //
-	///////////////////////
-
-	/** If true, return "{instructions}" else just "instructions" */
-	private ReprStream _repr(ReprStream stream, boolean print_braces) {
-		if (print_braces) stream.print("{");
-		
-		// Header
-		if (_locals != null) {
-			// Args
-			for (int i = _args.size()-1; i >= 0; i--) {
-				stream.print(_args.get(i).toString());
-				stream.print(" ");
-			}
-			
-			// Non-arg locals
-			if (_locals.size() != 0) {
-				stream.print(": ");
-			
-				// Print locals
-				for (Symbol key : _locals.keys()) {
-					stream.print(key.name());
-					stream.print("(");
-					_locals.get(key).repr(stream);
-					stream.print(")");
-				}
-			}
-			
-			// Trim off the final space
-			stream.delTrailingSpaces();
-			stream.print(",");
-		}
-
-		for(Instruction i : _instructions) {
-			i.repr(stream);
-			stream.print(" ");
-		}
-
-		// Remove trailing space
-		stream.delTrailingSpaces();
-
-		if (print_braces) stream.print("}");
-		return stream;
+	
+	public boolean hasLocals() {
+		return _locals != null;
 	}
 	
-
-	public ReprStream repr(ReprStream stream, boolean print_braces) {
-		if (stream.visit(this)) {
-			_repr(stream, print_braces);
-			stream.popVisited(this);
-		} else {
-			stream.print("{...}");
-		}
-		return stream;
-	}
+	//////////////////////
+	// Used By BlockOps //
+	//////////////////////
 	
-	@Override
-	public String toString() {
-		return repr(new ReprStream(), true).toStringOneline();
+	protected Dict getLocals() {
+		return _locals;
 	}
+
+	protected ArrayList<Instruction> getInstructions() {
+		return _instructions;
+	}
+
+	protected ArrayList<Assignment> getArgs() {
+		return _args;
+	}
+
+
 
 	///////////////////
 	// OBJ OVERRIDES //
@@ -126,12 +91,12 @@ public class StaticBlock extends Obj {
 
 	@Override
 	public ReprStream repr(ReprStream stream) {
-		return repr(stream, true);
+		return BlockUtils.repr(stream, this, true, null);
 	}
 
 	@Override
 	public String str() {
-		return repr(new ReprStream(), true).toStringOneline();
+		return BlockUtils.repr(new ReprStream(), this, true, null).toStringOneline();
 	}
 
 	@Override
@@ -148,6 +113,11 @@ public class StaticBlock extends Obj {
 	@Override
 	public byte type() {
 		return Obj.BLOCK;
+	}
+	
+	@Override
+	public String toString() {
+		return this.str();
 	}
 
 }

--- a/src/aya/obj/block/StaticBlock.java
+++ b/src/aya/obj/block/StaticBlock.java
@@ -18,7 +18,7 @@ public class StaticBlock extends Obj {
 	private ArrayList<Instruction> _instructions;
 	private ArrayList<Assignment> _args;
 	
-	public StaticBlock(ArrayList<Instruction> instructions, Dict locals, ArrayList<Assignment> args) {
+	protected StaticBlock(ArrayList<Instruction> instructions, Dict locals, ArrayList<Assignment> args) {
 		// If args is empty, just use null
 		if (args != null && args.size() == 0) args = null;
 
@@ -32,21 +32,27 @@ public class StaticBlock extends Obj {
 		}
 	}
 
-	public StaticBlock(ArrayList<Instruction> instructions) {
+	protected StaticBlock(ArrayList<Instruction> instructions) {
 		this(instructions, null, null);
 	}
 	
 	public void dumpToBlockEvaluator(Block b) {
 		if (_locals != null) {
 			Dict locals = _locals.clone();
-			for (Assignment arg : _args) {
-				arg.assign(locals, b.pop());
+
+			// Assign in reverse order
+			// aya> 1 2 3 {a b c, a b}
+			// 1 2
+			for (int i = _args.size()-1; i >= 0; i--) {
+				_args.get(i).assign(locals, b.pop());
 			}	
+
+			// Add a new variable frame to the variable stack
 			Aya.getInstance().getVars().add(locals);
+			// Pop the variable frame when the block is done
+			b.add(PopVarFlagInstruction.INSTANCE);
 			
 			b.addAll(_instructions);
-			
-			b.add(PopVarFlagInstruction.INSTANCE);
 		} else {
 			b.addAll(_instructions);
 		}

--- a/src/aya/obj/block/StaticBlock.java
+++ b/src/aya/obj/block/StaticBlock.java
@@ -1,0 +1,153 @@
+package aya.obj.block;
+
+import java.util.ArrayList;
+
+import aya.Aya;
+import aya.ReprStream;
+import aya.instruction.Instruction;
+import aya.instruction.flag.PopVarFlagInstruction;
+import aya.instruction.variable.assignment.Assignment;
+import aya.obj.Obj;
+import aya.obj.dict.Dict;
+import aya.obj.symbol.Symbol;
+
+public class StaticBlock extends Obj {
+	
+	private Dict _locals;
+	private ArrayList<Instruction> _instructions;
+	private ArrayList<Assignment> _args;
+	
+	public StaticBlock(ArrayList<Instruction> instructions, Dict locals, ArrayList<Assignment> args) {
+		// If args is empty, just use null
+		if (args != null && args.size() == 0) args = null;
+
+		_locals = locals;
+		_args = args;
+		_instructions = instructions;
+
+		// If we have args, locals is implied
+		if (_args != null && _locals == null) {
+			_locals = new Dict();
+		}
+	}
+	
+	public void dumpToBlockEvaluator(Block b) {
+		if (_locals != null) {
+			Dict locals = _locals.clone();
+			for (Assignment arg : _args) {
+				arg.assign(locals, b.pop());
+			}	
+			Aya.getInstance().getVars().add(locals);
+			
+			b.addAll(_instructions);
+			
+			b.add(PopVarFlagInstruction.INSTANCE);
+		} else {
+			b.addAll(_instructions);
+		}
+	}
+
+	///////////////////////
+	// String Conversion //
+	///////////////////////
+
+	/** If true, return "{instructions}" else just "instructions" */
+	private ReprStream _repr(ReprStream stream, boolean print_braces) {
+		if (print_braces) stream.print("{");
+		
+		// Header
+		if (_locals != null) {
+			// Args
+			for (int i = _args.size()-1; i >= 0; i--) {
+				stream.print(_args.get(i).toString());
+				stream.print(" ");
+			}
+			
+			// Non-arg locals
+			if (_locals.size() != 0) {
+				stream.print(": ");
+			
+				// Print locals
+				for (Symbol key : _locals.keys()) {
+					stream.print(key.name());
+					stream.print("(");
+					_locals.get(key).repr(stream);
+					stream.print(")");
+				}
+			}
+			
+			// Trim off the final space
+			stream.delTrailingSpaces();
+			stream.print(",");
+		}
+
+		for(Instruction i : _instructions) {
+			i.repr(stream);
+			stream.print(" ");
+		}
+
+		// Remove trailing space
+		stream.delTrailingSpaces();
+
+		if (print_braces) stream.print("}");
+		return stream;
+	}
+	
+
+	public ReprStream repr(ReprStream stream, boolean print_braces) {
+		if (stream.visit(this)) {
+			_repr(stream, print_braces);
+			stream.popVisited(this);
+		} else {
+			stream.print("{...}");
+		}
+		return stream;
+	}
+	
+	@Override
+	public String toString() {
+		return repr(new ReprStream(), true).toStringOneline();
+	}
+
+	///////////////////
+	// OBJ OVERRIDES //
+	///////////////////
+	
+	
+	@Override
+	public Obj deepcopy() {
+		return this;
+	}
+
+	@Override
+	public boolean bool() {
+		return true;
+	}
+
+	@Override
+	public ReprStream repr(ReprStream stream) {
+		return repr(stream, true);
+	}
+
+	@Override
+	public String str() {
+		return repr(new ReprStream(), true).toStringOneline();
+	}
+
+	@Override
+	public boolean equiv(Obj o) {
+		// Always return false
+		return false;
+	}
+
+	@Override
+	public boolean isa(byte type) {
+		return type == Obj.BLOCK;
+	}
+
+	@Override
+	public byte type() {
+		return Obj.BLOCK;
+	}
+
+}

--- a/src/aya/obj/block/StaticBlock.java
+++ b/src/aya/obj/block/StaticBlock.java
@@ -40,12 +40,14 @@ public class StaticBlock extends Obj {
 		if (_locals != null) {
 			Dict locals = _locals.clone();
 
-			// Assign in reverse order
-			// aya> 1 2 3 {a b c, a b}
-			// 1 2
-			for (int i = _args.size()-1; i >= 0; i--) {
-				_args.get(i).assign(locals, b.pop());
-			}	
+			if (_args != null) {
+				// Assign in reverse order
+				// aya> 1 2 3 {a b c, a b}
+				// 1 2
+				for (int i = _args.size()-1; i >= 0; i--) {
+					_args.get(i).assign(locals, b.pop());
+				}	
+			}
 
 			// Add a new variable frame to the variable stack
 			Aya.getInstance().getVars().add(locals);

--- a/src/aya/obj/dict/Dict.java
+++ b/src/aya/obj/dict/Dict.java
@@ -238,8 +238,9 @@ public class Dict extends Obj {
 			return true;
 		} else {
 			if (bool.isa(Obj.BLOCK)) {
-				Block blk_bool = new Block(Casting.asStaticBlock(bool));
+				Block blk_bool = new Block();
 				blk_bool.push(this);
+				blk_bool.dump(Casting.asStaticBlock(bool));
 				blk_bool.eval();
 				Obj obj_res = blk_bool.pop();
 				return obj_res.bool();
@@ -267,8 +268,9 @@ public class Dict extends Obj {
 			return dictStr();
 		} else {
 			if (str.isa(Obj.BLOCK)) {
-				Block blk_str = new Block(Casting.asStaticBlock(str));
+				Block blk_str = new Block();
 				blk_str.push(this);
+				blk_str.dump(Casting.asStaticBlock(str));
 				blk_str.eval();
 				Obj obj_res = blk_str.pop();
 				return obj_res.str();
@@ -348,8 +350,9 @@ public class Dict extends Obj {
 
 		if (repr != null) {
 			if (repr.isa(Obj.BLOCK)) {
-				Block blk_repr = new Block(Casting.asStaticBlock(repr));
+				Block blk_repr = new Block();
 				blk_repr.push(this);
+				blk_repr.dump(Casting.asStaticBlock(repr));
 				try {
 					blk_repr.eval();
 				} catch (AyaRuntimeException ex) {

--- a/src/aya/obj/dict/Dict.java
+++ b/src/aya/obj/dict/Dict.java
@@ -10,6 +10,7 @@ import aya.exceptions.runtime.AyaRuntimeException;
 import aya.exceptions.runtime.IndexError;
 import aya.obj.Obj;
 import aya.obj.block.Block;
+import aya.obj.block.StaticBlock;
 import aya.obj.symbol.Symbol;
 import aya.obj.symbol.SymbolConstants;
 import aya.util.Casting;
@@ -425,11 +426,11 @@ public class Dict extends Obj {
 	/** Given a block, swap all references to variables defined in the dict
 	 * with the values corresponding to the keys in the dict.
 	 * @param d
-	 * @param b
+	 * @param blk
 	 */
-	public static void assignVarValues(Dict d, Block b) {
-		for (Pair<Symbol, Obj> pair : d.getAllVars()) {
-			b.getInstructions().assignVarValue(pair.first(), pair.second());
+	public static void assignVarValues(Dict d, StaticBlock blk) {
+		for (Pair<Symbol, Obj> pair : d.items()) {
+			blk.getInstructions().assignVarValue(pair.first(), pair.second());
 		}
 	}
 
@@ -456,17 +457,6 @@ public class Dict extends Obj {
 	
 
 
-	/** Return all variables as a list of pairs */
-	private ArrayList<Pair<Symbol, Obj>> getAllVars() {
-		ArrayList<Pair<Symbol,Obj>> out = new ArrayList<Pair<Symbol, Obj>>();
-		Iterator<HashMap.Entry<Symbol, Obj>> it = _vars.entrySet().iterator();
-	    while (it.hasNext()) {
-	    	HashMap.Entry<Symbol,Obj> pair = (HashMap.Entry<Symbol, Obj>)it.next();
-	    	out.add(new Pair<Symbol, Obj>(pair.getKey(), pair.getValue()));
-	    }
-	    return out;
-	}
-	
 	private HashMap<Symbol, Obj> deepcopyHashMap() {
 		// Copy the hash map
 		HashMap<Symbol, Obj> vars_copy = new HashMap<Symbol, Obj>();

--- a/src/aya/obj/dict/Dict.java
+++ b/src/aya/obj/dict/Dict.java
@@ -10,7 +10,6 @@ import aya.exceptions.runtime.AyaRuntimeException;
 import aya.exceptions.runtime.IndexError;
 import aya.obj.Obj;
 import aya.obj.block.Block;
-import aya.obj.block.StaticBlock;
 import aya.obj.symbol.Symbol;
 import aya.obj.symbol.SymbolConstants;
 import aya.util.Casting;
@@ -239,7 +238,7 @@ public class Dict extends Obj {
 			return true;
 		} else {
 			if (bool.isa(Obj.BLOCK)) {
-				Block blk_bool = ((Block)bool).duplicate();
+				Block blk_bool = new Block(Casting.asStaticBlock(bool));
 				blk_bool.push(this);
 				blk_bool.eval();
 				Obj obj_res = blk_bool.pop();
@@ -268,7 +267,7 @@ public class Dict extends Obj {
 			return dictStr();
 		} else {
 			if (str.isa(Obj.BLOCK)) {
-				Block blk_str = ((Block)str).duplicate();
+				Block blk_str = new Block(Casting.asStaticBlock(str));
 				blk_str.push(this);
 				blk_str.eval();
 				Obj obj_res = blk_str.pop();
@@ -349,7 +348,7 @@ public class Dict extends Obj {
 
 		if (repr != null) {
 			if (repr.isa(Obj.BLOCK)) {
-				Block blk_repr = Casting.asBlock(repr).duplicate();
+				Block blk_repr = new Block(Casting.asStaticBlock(repr));
 				blk_repr.push(this);
 				try {
 					blk_repr.eval();
@@ -423,16 +422,6 @@ public class Dict extends Obj {
 	// STATIC METHODS //
 	////////////////////
 	
-	/** Given a block, swap all references to variables defined in the dict
-	 * with the values corresponding to the keys in the dict.
-	 * @param d
-	 * @param blk
-	 */
-	public static void assignVarValues(Dict d, StaticBlock blk) {
-		for (Pair<Symbol, Obj> pair : d.items()) {
-			blk.getInstructions().assignVarValue(pair.first(), pair.second());
-		}
-	}
 
 	/** Returns true if the metatable defines a given key */
 	public boolean hasMetaKey(Symbol v) {

--- a/src/aya/obj/dict/DictIndexing.java
+++ b/src/aya/obj/dict/DictIndexing.java
@@ -8,9 +8,11 @@ import aya.Aya;
 import aya.exceptions.runtime.IndexError;
 import aya.obj.Obj;
 import aya.obj.block.Block;
+import aya.obj.block.StaticBlock;
 import aya.obj.list.List;
 import aya.obj.symbol.Symbol;
 import aya.obj.symbol.SymbolConstants;
+import aya.util.Casting;
 
 public class DictIndexing {
 	
@@ -43,7 +45,7 @@ public class DictIndexing {
 			}
 			return new List(out);
 		} else if (index.isa(Obj.BLOCK)) {
-			return filter(dict, (Block)index);
+			return filter(dict, Casting.asStaticBlock(index));
 		} else {
 			throw new IndexError(dict, index, true);
 		}
@@ -58,13 +60,13 @@ public class DictIndexing {
 	}
 	
 	
-	public static Dict map(Dict dict, Block block) {
+	public static Dict map(Dict dict, StaticBlock mapBlock) {
 		Dict out = new Dict();
 		Block b = new Block();
 
 		ArrayList<Symbol> symKeys = dict.keys();
 		for (Symbol key : symKeys) {
-			b.addAll(block.getInstructions().getInstrucionList());
+			b.dump(mapBlock);
 			b.push(key);
 			b.push(dict.get(key));
 			b.eval();
@@ -77,13 +79,13 @@ public class DictIndexing {
 	}
 
 
-	public static Dict filter(Dict dict, Block block) {
+	public static Dict filter(Dict dict, StaticBlock filterBlock) {
 		Dict out = new Dict();
 		Block b = new Block();
 
 		ArrayList<Symbol> symKeys = dict.keys();
 		for (Symbol key : symKeys) {
-			b.addAll(block.getInstructions().getInstrucionList());
+			b.dump(filterBlock);
 			b.push(key);
 			b.push(dict.get(key));
 			b.eval();

--- a/src/aya/obj/list/List.java
+++ b/src/aya/obj/list/List.java
@@ -360,13 +360,13 @@ public class List extends Obj {
 	 * Same as map but push 1 additional item to the stack (shallow copied)
 	 * Maps a block to a list and returns the new list. The block is not effected
 	 */
-	public List map1arg(Block block, Obj obj) {
+	public List map1arg(StaticBlock expr, Obj obj) {
 		int len = length();
 		ArrayList<Obj> out = new ArrayList<Obj>(len);
 		Block b = new Block();
 		for (int i = 0; i < len; i++) {
 			b.push(obj);
-			b.addAll(block.getInstructions().getInstrucionList());
+			b.addAll(expr.getInstructions().getInstrucionList());
 			b.add(new DataInstruction(getExact(i)));
 			b.eval();
 			out.addAll(b.getStack());

--- a/src/aya/obj/list/List.java
+++ b/src/aya/obj/list/List.java
@@ -14,6 +14,7 @@ import aya.exceptions.runtime.ValueError;
 import aya.instruction.DataInstruction;
 import aya.obj.Obj;
 import aya.obj.block.Block;
+import aya.obj.block.StaticBlock;
 import aya.obj.list.numberlist.DoubleList;
 import aya.obj.list.numberlist.NumberList;
 import aya.obj.number.Num;
@@ -338,13 +339,13 @@ public class List extends Obj {
 	/** 
 	 * Maps a block to a list and returns the new list. The block is not effected
 	 */
-	public List map(Block block) {
+	public List map(StaticBlock map) {
 		int len = length();
 		if (len > 0) {
 			ArrayList<Obj> out = new ArrayList<Obj>(len);
 			Block b = new Block();
 			for (int i = 0; i < len; i++) {
-				b.addAll(block.getInstructions().getInstrucionList());
+				b.dump(map);
 				b.add(new DataInstruction(getExact(i)));
 				b.eval();
 				out.addAll(b.getStack());
@@ -377,16 +378,16 @@ public class List extends Obj {
 	/**
 	 * Filter a list using the block
 	 * 
-	 * @param block
+	 * @param filter
 	 * @param list
 	 * @return
 	 */
-	public List filter(Block block) {
+	public List filter(StaticBlock filter) {
 		ArrayList<Obj> out = new ArrayList<Obj>();
 		Block b = new Block();
 		for (int i = 0; i < length(); i++) {
 			final Obj o = getExact(i);
-			b.addAll(block.getInstructions().getInstrucionList());
+			b.dump(filter);
 			b.add(new DataInstruction(o));
 			b.eval();
 			if(b.peek().bool()) {

--- a/src/aya/obj/list/List.java
+++ b/src/aya/obj/list/List.java
@@ -1,6 +1,5 @@
 package aya.obj.list;
 
-import static aya.util.Casting.asBlock;
 import static aya.util.Casting.asList;
 import static aya.util.Casting.asNumber;
 import static aya.util.Casting.asNumberList;
@@ -366,7 +365,7 @@ public class List extends Obj {
 		Block b = new Block();
 		for (int i = 0; i < len; i++) {
 			b.push(obj);
-			b.addAll(expr.getInstructions().getInstrucionList());
+			b.dump(expr);
 			b.add(new DataInstruction(getExact(i)));
 			b.eval();
 			out.addAll(b.getStack());
@@ -401,15 +400,15 @@ public class List extends Obj {
 	/**
 	 * Filter a list using the block
 	 * 
-	 * @param block
+	 * @param staticBlock
 	 * @param list
 	 * @return
 	 */
-	public List filter(Block block, Obj dflt) {
+	public List filter(StaticBlock staticBlock, Obj dflt) {
 		ArrayList<Obj> out = new ArrayList<Obj>(length());
 		Block b = new Block();
 		for (int i = 0; i < length(); i++) {
-			b.addAll(block.getInstructions().getInstrucionList());
+			b.dump(staticBlock);
 			b.add(new DataInstruction(getExact(i)));
 			b.eval();
 			if(b.peek().bool()) {
@@ -428,12 +427,12 @@ public class List extends Obj {
 	 * @param list
 	 * @return
 	 */
-	public boolean[] filterIndex(Block block) {
+	public boolean[] filterIndex(StaticBlock staticBlock) {
 		final int len = length();
 		boolean[] out = new boolean[len];
 		Block b = new Block();
 		for (int i = 0; i < len; i++) {
-			b.addAll(block.getInstructions().getInstrucionList());
+			b.dump(staticBlock);
 			b.add(new DataInstruction(getExact(i)));
 			b.eval();
 			out[i] = b.peek().bool();
@@ -632,7 +631,7 @@ public class List extends Obj {
 			}
 		} 
 		else if (index.isa(Obj.BLOCK)) {
-			return filter((Block)index);
+			return filter(Casting.asStaticBlock(index));
 		} else {
 			throw new TypeError("Cannot index list using object:\n"
 					+ "list:\t" + repr() + "\n"
@@ -664,7 +663,7 @@ public class List extends Obj {
 			}
 		} 
 		else if (index.isa(Obj.BLOCK)) {
-			return filter((Block)index, dflt);
+			return filter(Casting.asStaticBlock(index), dflt);
 		} else {
 			throw new TypeError("Cannot index list using object:\n"
 					+ "list:\t" + repr() + "\n"
@@ -886,7 +885,7 @@ public class List extends Obj {
 			}
 		} 
 		else if (index.isa(Obj.BLOCK)) {
-			boolean[] truthIdxs = filterIndex(asBlock(index));
+			boolean[] truthIdxs = filterIndex(Casting.asStaticBlock(index));
 			for (int i = 0; i < length(); i++) {
 				if (truthIdxs[i]) {
 					mutSetExact(i, item);

--- a/src/aya/parser/Parser.java
+++ b/src/aya/parser/Parser.java
@@ -30,6 +30,7 @@ import aya.instruction.variable.SetKeyVariableInstruction;
 import aya.instruction.variable.SetVariableInstruction;
 import aya.obj.Obj;
 import aya.obj.block.Block;
+import aya.obj.block.BlockUtils;
 import aya.obj.list.List;
 import aya.obj.number.Number;
 import aya.obj.symbol.SymbolTable;
@@ -617,7 +618,7 @@ public class Parser {
 							// Small optimization for single variable indices
 							is.push(new GetVarIndexInstruction(current.getSourceStringRef(), ((GetVariableInstruction) instructions.get(0)).getSymbol()));
 						} else {
-							is.push(new GetExprIndexInstruction(current.getSourceStringRef(), new Block(lli.getInstructions())));
+							is.push(new GetExprIndexInstruction(current.getSourceStringRef(), BlockUtils.fromIS(lli.getInstructions())));
 						}
 					}
 				}
@@ -656,7 +657,7 @@ public class Parser {
 							// Small optimization for single variable indices
 							is.push(new SetVarIndexInstruction(current.getSourceStringRef(), ((GetVariableInstruction) instructions.get(0)).getSymbol()));
 						} else {
-							is.push(new SetExprIndexInstruction(current.getSourceStringRef(), new Block(lli.getInstructions())));
+							is.push(new SetExprIndexInstruction(current.getSourceStringRef(), BlockUtils.fromIS(lli.getInstructions())));
 						}
 					}
 				}
@@ -730,18 +731,18 @@ public class Parser {
 				return (BlockLiteralInstruction)next;
 			} else {
 				// Create a block and apply it to a list
-				Block colonBlock = new Block();
+				InstructionStack colonBlock = new InstructionStack();
 				is.push(next); // Add next back in
 
 				while (!is.isEmpty()) {
 					Instruction o = is.pop();
-					colonBlock.getInstructions().insert(0, o);
+					colonBlock.insert(0, o);
 					if (o instanceof OperatorInstruction || o instanceof GetVariableInstruction
 							|| o instanceof GetKeyVariableInstruction) {
 						break;
 					}
 				}
-				return new BlockLiteralInstruction(ref, colonBlock);
+				return new BlockLiteralInstruction(ref, BlockUtils.fromIS(colonBlock));
 			}
 		}
 	}

--- a/src/aya/parser/tokens/BlockToken.java
+++ b/src/aya/parser/tokens/BlockToken.java
@@ -43,7 +43,7 @@ public class BlockToken extends CollectionToken {
 		ArrayList<TokenQueue> blockData = splitCommas(col);
 		if (blockData.size() == 1) {
 			InstructionStack instructions = Parser.generate(blockData.get(0));
-			return new BlockLiteralInstruction(this.getSourceStringRef(), new StaticBlock(instructions.getInstrucionList()));
+			return new BlockLiteralInstruction(this.getSourceStringRef(), BlockUtils.fromIS(instructions));
 		} else {
 			TokenQueue header = blockData.get(0);
 
@@ -54,7 +54,7 @@ public class BlockToken extends CollectionToken {
 					if (instructions.size() == 0) {
 						return EmptyDictLiteralInstruction.INSTANCE;
 					} else {
-						return new DictLiteralInstruction(this.getSourceStringRef(), new StaticBlock(instructions.getInstrucionList()));
+						return new DictLiteralInstruction(this.getSourceStringRef(), BlockUtils.fromIS(instructions));
 					}
 				}
 				// Single number in header, create a dict factory with a capture
@@ -74,14 +74,14 @@ public class BlockToken extends CollectionToken {
 					if (n == 0 && instructions.isEmpty()) {
 						return EmptyDictLiteralInstruction.INSTANCE;
 					} else {
-						return new DictLiteralInstruction(this.getSourceStringRef(), new StaticBlock(instructions.getInstrucionList()), n);
+						return new DictLiteralInstruction(this.getSourceStringRef(), BlockUtils.fromIS(instructions), n);
 					}
 				}
 				//Non-empty header, args and local variables
 				else {
 					InstructionStack main_instructions = Parser.generate(blockData.get(1));
 					Triple<ArrayList<Assignment>, Dict, HashMap<Symbol, StaticBlock>> p = generateBlockHeader(blockData.get(0));
-					StaticBlock blk = new StaticBlock(main_instructions.getInstrucionList(), p.second(), p.first());
+					StaticBlock blk = BlockUtils.fromIS(main_instructions, p.second(), p.first());
 					return new BlockLiteralInstruction(this.getSourceStringRef(), blk, p.third());
 				}
 			} else {
@@ -202,7 +202,7 @@ public class BlockToken extends CollectionToken {
 					locals.set(var.getSymbol(), Num.ZERO);
 				} else if (tokens.peek().isa(Token.LAMBDA)){
 					LambdaToken lambda = (LambdaToken)tokens.next();
-					captures.put(var.getSymbol(), new StaticBlock(lambda.generateInstructionsForFirst().getInstrucionList()));
+					captures.put(var.getSymbol(), BlockUtils.fromIS(lambda.generateInstructionsForFirst()));
 				} else if (tokens.peek().isa(Token.OP)) {
 					OperatorToken opt = (OperatorToken)tokens.next();
 					if (opt.data.equals("^")) {

--- a/src/aya/parser/tokens/LambdaToken.java
+++ b/src/aya/parser/tokens/LambdaToken.java
@@ -14,7 +14,7 @@ import aya.instruction.LambdaInstruction;
 import aya.instruction.TupleInstruction;
 import aya.instruction.variable.GetVariableInstruction;
 import aya.obj.Obj;
-import aya.obj.block.Block;
+import aya.obj.block.StaticBlock;
 import aya.parser.Parser;
 import aya.parser.SourceStringRef;
 import aya.parser.token.TokenQueue;
@@ -52,9 +52,9 @@ public class LambdaToken extends CollectionToken {
 				return new LambdaInstruction(this.getSourceStringRef(), lambdaIL);
 			}
 		} else {
-			Block[] elements = new Block[lambdaData.size()];
+			StaticBlock[] elements = new StaticBlock[lambdaData.size()];
 			for (int k = 0; k < elements.length; k++) {
-				elements[k] = new Block(Parser.generate(lambdaData.get(k)));
+				elements[k] = new StaticBlock(Parser.generate(lambdaData.get(k)).getInstrucionList());
 			}
 			return new TupleInstruction(this.getSourceStringRef(), elements);
 		}

--- a/src/aya/parser/tokens/LambdaToken.java
+++ b/src/aya/parser/tokens/LambdaToken.java
@@ -14,6 +14,7 @@ import aya.instruction.LambdaInstruction;
 import aya.instruction.TupleInstruction;
 import aya.instruction.variable.GetVariableInstruction;
 import aya.obj.Obj;
+import aya.obj.block.BlockUtils;
 import aya.obj.block.StaticBlock;
 import aya.parser.Parser;
 import aya.parser.SourceStringRef;
@@ -54,7 +55,7 @@ public class LambdaToken extends CollectionToken {
 		} else {
 			StaticBlock[] elements = new StaticBlock[lambdaData.size()];
 			for (int k = 0; k < elements.length; k++) {
-				elements[k] = new StaticBlock(Parser.generate(lambdaData.get(k)).getInstrucionList());
+				elements[k] = BlockUtils.fromIS(Parser.generate(lambdaData.get(k)));
 			}
 			return new TupleInstruction(this.getSourceStringRef(), elements);
 		}

--- a/src/aya/parser/tokens/ListToken.java
+++ b/src/aya/parser/tokens/ListToken.java
@@ -7,9 +7,11 @@ import aya.exceptions.parser.SyntaxError;
 import aya.instruction.BlockLiteralInstruction;
 import aya.instruction.EmptyListLiteralInstruction;
 import aya.instruction.Instruction;
+import aya.instruction.InstructionStack;
 import aya.instruction.ListBuilderInstruction;
 import aya.instruction.ListLiteralInstruction;
-import aya.obj.block.Block;
+import aya.obj.block.BlockUtils;
+import aya.obj.block.StaticBlock;
 import aya.parser.Parser;
 import aya.parser.SourceStringRef;
 import aya.parser.token.TokenQueue;
@@ -39,12 +41,13 @@ public class ListToken extends CollectionToken {
 			return ll;
 		case 2:
 		{
-			Block initialList = new Block(Parser.generate(listData.get(0)));			
-			Block map = new Block(Parser.generate(listData.get(1)));
-			BlockLiteralInstruction bli = map.getInstructions().getIfSingleBlockInstruction();
+			StaticBlock initialList = BlockUtils.fromIS(Parser.generate(listData.get(0)));			
+			InstructionStack map_is = Parser.generate(listData.get(1));
+			BlockLiteralInstruction bli = map_is.getIfSingleBlockInstruction();
 
-			if (map.getInstructions().isEmpty()) {
-				map = null;
+			StaticBlock map = null;
+			if (!map_is.isEmpty()) {
+				map = BlockUtils.fromIS(map_is);
 			} 
 			
 			if (bli != null) {
@@ -55,27 +58,29 @@ public class ListToken extends CollectionToken {
 		}
 		default:
 		{ 
-			Block initialList2 = new Block(Parser.generate(listData.get(0)));
-			Block map2 = new Block(Parser.generate(listData.get(1)));
-			if (map2.getInstructions().isEmpty()) {
-				map2 = null;
+			StaticBlock initialList2 = BlockUtils.fromIS(Parser.generate(listData.get(0)));
+			InstructionStack map2_is = Parser.generate(listData.get(1));
+
+			StaticBlock map2 = null;
+			if (!map2_is.isEmpty()) {
+				map2 = BlockUtils.fromIS(map2_is);
 			}
 			
-			Block[] filters = new Block[listData.size()-2];
+			StaticBlock[] filters = new StaticBlock[listData.size()-2];
 			for(int k = 2; k < listData.size(); k++) {
 				if (listData.get(k).size() == 0) {
 					throw new SyntaxError("List Comprehension filters must not be empty [" + initialList2 + ", " + map2 + ", ]", this.getSourceStringRef());
 				}
 				//filters[k-2] = new Block(generate(listData.get(k)));
-				Block tmpFilter = new Block(Parser.generate(listData.get(k)));
+				InstructionStack tmpFilter_is = Parser.generate(listData.get(k));
 				
 				//If the filter clause only contains a single block, set them to auto eval
-				BlockLiteralInstruction bli = tmpFilter.getInstructions().getIfSingleBlockInstruction();
+				BlockLiteralInstruction bli = tmpFilter_is.getIfSingleBlockInstruction();
 				if (bli != null) {
 					bli.setAutoEval();
 				}
 				
-				filters[k-2] = tmpFilter;
+				filters[k-2] = BlockUtils.fromIS(tmpFilter_is);
 			}
 			return new ListBuilderInstruction(this.getSourceStringRef(), initialList2, map2, filters, pops);
 		} //End default scope

--- a/src/aya/parser/tokens/StringToken.java
+++ b/src/aya/parser/tokens/StringToken.java
@@ -8,7 +8,7 @@ import aya.instruction.InstructionStack;
 import aya.instruction.InterpolateStringInstruction;
 import aya.instruction.StringLiteralInstruction;
 import aya.instruction.variable.GetVariableInstruction;
-import aya.obj.block.StaticBlock;
+import aya.obj.block.BlockUtils;
 import aya.obj.list.List;
 import aya.obj.symbol.SymbolTable;
 import aya.parser.Parser;
@@ -126,7 +126,7 @@ public class StringToken extends StdToken {
 					
 					//Add the block
 					InstructionStack is = Parser.compileIS(new ParserString(in.currentRef(), block.toString()) , Aya.getInstance());
-					instrs.insert(0, new StaticBlock(is.getInstrucionList()));
+					instrs.insert(0, BlockUtils.fromIS(is));
 					
 				}
 				

--- a/src/aya/parser/tokens/StringToken.java
+++ b/src/aya/parser/tokens/StringToken.java
@@ -8,7 +8,7 @@ import aya.instruction.InstructionStack;
 import aya.instruction.InterpolateStringInstruction;
 import aya.instruction.StringLiteralInstruction;
 import aya.instruction.variable.GetVariableInstruction;
-import aya.obj.block.Block;
+import aya.obj.block.StaticBlock;
 import aya.obj.list.List;
 import aya.obj.symbol.SymbolTable;
 import aya.parser.Parser;
@@ -125,7 +125,8 @@ public class StringToken extends StdToken {
 					sb.setLength(0);
 					
 					//Add the block
-					instrs.insert(0, new Block(Parser.compileIS(new ParserString(in.currentRef(), block.toString()), Aya.getInstance())));
+					InstructionStack is = Parser.compileIS(new ParserString(in.currentRef(), block.toString()) , Aya.getInstance());
+					instrs.insert(0, new StaticBlock(is.getInstrucionList()));
 					
 				}
 				

--- a/src/aya/util/Casting.java
+++ b/src/aya/util/Casting.java
@@ -1,7 +1,7 @@
 package aya.util;
 
 import aya.obj.Obj;
-import aya.obj.block.Block;
+import aya.obj.block.StaticBlock;
 import aya.obj.character.Char;
 import aya.obj.dict.Dict;
 import aya.obj.list.List;
@@ -34,10 +34,10 @@ public class Casting {
 		return List.asStr(asList(o));
 	}
 	
-	public static Block asBlock(Obj o) {
-		return (Block)o;
+	public static StaticBlock asStaticBlock(Obj o) {
+		return (StaticBlock)o;
 	}
-	
+
 	public static Symbol asSymbol(Obj o) {
 		return (Symbol)o;
 	}

--- a/test/base/test_block.aya
+++ b/test/base/test_block.aya
@@ -24,19 +24,7 @@
     {, 1:copy; ::b:name; ::str:type; ::typed:argtype; } ] 
 }
 
-{ {}.makelocals .locals {,} }
-{ {:a,}.makelocals .locals {,0:a} }
-
-{ [::x] {}.setlocals .locals {, 0:x} }
-.# block is wrapped, not merged
-{ [::x] {:y,}.setlocals .locals {, 0:x} }
 
 {:a, 1:a; {a}.use[::a] ~ 1 }
-
-{:a, 1:a; {a}.capture[::a] 2:a; ~ 1 }
-
-{:a, 1:a; {a}.where_const{, 10:a } ~ 10 }
-
-{:a, 1:a; {a}.where{, 10:a } ~ 10 }
 
 ] :# { test.test }


### PR DESCRIPTION
Previously, the `Block` object was used for both storing instructions and evaluating the stack. This was split into two separate objects:

  - `Block` (will be renamed to `BlockEvaluator`) is used for evaluating the stack
  - `StaticBlock` (will be renamed to `Block`) is the new `aya.obj.block.Block` Aya object. It is read only. Modified copies can be made using the `BlockUtils` class

The primary reason for this change is to prepare upcoming work on a new preprocessor and macros

Though performance wasn't the primary reason for this change, generally, Aya programs run about 5-7% faster.

More details TBD
