### PR TITLE
Add .Z operator for computing permutations

### DIFF
--- a/src/aya/instruction/op/DotOps.java
+++ b/src/aya/instruction/op/DotOps.java
@@ -133,7 +133,7 @@ public class DotOps {
 		/* 87 W  */ null,
 		/* 88 X  */ null,
 		/* 89 Y  */ null,
-		/* 90 Z  */ null,
+		/* 90 Z  */ new OP_Dot_Z(),
 		/* 91 [  */ null,
 		/* 92 \  */ new OP_Dot_BackSlash(),
 		/* 93 ]  */ null,
@@ -1409,6 +1409,27 @@ class OP_Dot_AppendBack extends OpInstruction {
 			block.push(a);
 		} else {
 			throw new TypeError(this, a, b);
+		}
+	}
+}
+
+
+// Z - 90
+class OP_Dot_Z extends OpInstruction {
+
+	public OP_Dot_Z() {
+		init(".Z");
+		arg("L", "permutations");
+	}
+
+	@Override
+	public void execute(Block block) {
+		Obj a = block.pop();
+
+		if (a.isa(LIST)) {
+			block.push(asList(a).permutations());
+		} else {
+			throw new TypeError(this, a);
 		}
 	}
 }

--- a/src/aya/obj/list/GenericList.java
+++ b/src/aya/obj/list/GenericList.java
@@ -321,6 +321,11 @@ public class GenericList extends ListImpl {
 			}
 		}
 	}
+	
+	@Override
+	public List permutations() {
+		return Permutations.allPermutations(_list);
+	}
 
 	@Override
 	protected ListImpl flatten() {

--- a/src/aya/obj/list/List.java
+++ b/src/aya/obj/list/List.java
@@ -729,6 +729,10 @@ public class List extends Obj {
 		return _list.sameShapeNull();
 	}
 	
+	public List permutations() {
+		return _list.permutations();
+	}
+	
 	////////////////////////
 	// LIST MODIFICATIONS //
 	////////////////////////

--- a/src/aya/obj/list/ListImpl.java
+++ b/src/aya/obj/list/ListImpl.java
@@ -98,6 +98,10 @@ public abstract class ListImpl {
 
 	/** Return a null filled list that is the same shape as the callee */
 	public abstract List sameShapeNull();
+	
+	/** Return a list of all permutations of this list. May contain
+	 * duplicates if the source list contains duplicates */
+	public abstract List permutations();
 
 	/** Return a flattened version of the list */
 	protected abstract ListImpl flatten();

--- a/src/aya/obj/list/Permutations.java
+++ b/src/aya/obj/list/Permutations.java
@@ -1,0 +1,117 @@
+package aya.obj.list;
+
+import java.util.ArrayList;
+
+import aya.ReprStream;
+import aya.obj.Obj;
+import aya.obj.character.Char;
+import aya.obj.list.numberlist.DoubleList;
+import aya.obj.number.Num;
+
+public class Permutations {
+
+	// Java Generics == :(
+	// We need to define implementations for char[], double[], and ArrayList<Obj>
+
+	private static void swap(char[] input, int a, int b) {
+	    char tmp = input[a];
+	    input[a] = input[b];
+	    input[b] = tmp;
+	}
+
+	private static void swap(double[] input, int a, int b) {
+	    double tmp = input[a];
+	    input[a] = input[b];
+	    input[b] = tmp;
+	}
+	
+	private static <T extends Obj> void swap(ArrayList<T> input, int a, int b) {
+		T tmp = input.get(a);
+		input.set(a, input.get(b));
+		input.set(b,  tmp);
+	}
+
+	private static void permutations(List agg, int n, char[] elements) {
+	    if (n == 1) {
+	    	agg.mutAdd(List.fromString(new String(elements)));
+	    } else {
+	        for (int i = 0; i < n - 1; i++) {
+	            permutations(agg, n-1, elements);
+	            if (n % 2 == 0) {
+	                swap(elements, i, n - 1);
+	            } else {
+	                swap(elements, 0, n - 1);
+	            }
+	        }
+	        permutations(agg, n-1, elements);
+	    }
+	}
+	
+	private static void permutations(List agg, int n, double[] elements) {
+	    if (n == 1) {
+	    	agg.mutAdd(new List(DoubleList.copyOf(elements)));
+	    } else {
+	        for (int i = 0; i < n - 1; i++) {
+	            permutations(agg, n-1, elements);
+	            if (n % 2 == 0) {
+	                swap(elements, i, n - 1);
+	            } else {
+	                swap(elements, 0, n - 1);
+	            }
+	        }
+	        permutations(agg, n-1, elements);
+	    }
+	}
+	
+	private static <T extends Obj> void permutations(List agg, int n, ArrayList<T> elements) {
+	    if (n == 1) {
+	    	ArrayList<Obj> copy = new ArrayList<Obj>(elements.size());
+	    	copy.addAll(elements);
+	    	agg.mutAdd(new List(new GenericList(copy).promote()));
+	    } else {
+	        for (int i = 0; i < n - 1; i++) {
+	            permutations(agg, n-1, elements);
+	            if (n % 2 == 0) {
+	                swap(elements, i, n - 1);
+	            } else {
+	                swap(elements, 0, n - 1);
+	            }
+	        }
+	        permutations(agg, n-1, elements);
+	    }
+	}
+	
+	
+	public static List allPermutations(char[] elements) {
+		List perms = new List();
+		permutations(perms, elements.length, elements);
+		return perms;
+	}
+
+	
+	public static List allPermutations(double[] elements) {
+		List perms = new List();
+		permutations(perms, elements.length, elements);
+		return perms;
+	}
+	
+	
+	public static <T extends Obj> List allPermutations(ArrayList<T> elements) {
+		List perms = new List();
+		permutations(perms, elements.size(), elements);
+		return perms;
+	}
+
+	
+	public static void main(String[] args) {
+		System.out.println(allPermutations(new String("abc").toCharArray()).repr());
+		double[] double_test = {1.0, 2.0, 3.0};
+		System.out.println(allPermutations(double_test).repr());
+		ArrayList<Obj> l = new ArrayList<Obj>();
+		l.add(Num.ONE);
+		l.add(Char.valueOf('c'));
+		l.add(new List());
+		System.out.println(allPermutations(l).repr());
+	}
+
+}

--- a/src/aya/obj/list/Str.java
+++ b/src/aya/obj/list/Str.java
@@ -385,6 +385,11 @@ public class Str extends ListImpl implements Comparable<Str> {
 	public List sameShapeNull() {
 		return new List(new Str(' ', length()));
 	}
+	
+	@Override
+	public List permutations() {
+		return Permutations.allPermutations(_str.toCharArray());
+	}
 
 	@Override
 	protected ListImpl flatten() {

--- a/src/aya/obj/list/numberlist/DoubleList.java
+++ b/src/aya/obj/list/numberlist/DoubleList.java
@@ -11,6 +11,7 @@ import aya.obj.Obj;
 import aya.obj.list.List;
 import aya.obj.list.ListAlgorithms;
 import aya.obj.list.ListImpl;
+import aya.obj.list.Permutations;
 import aya.obj.number.Num;
 import aya.obj.number.Number;
 import aya.util.Casting;
@@ -71,6 +72,12 @@ public class DoubleList extends NumberList {
 			out[i] = (double)bytes[i];
 		}
 		return new DoubleList(out);
+	}
+	
+	public static DoubleList copyOf(double[] elements) {
+		double[] list = new double[elements.length];
+		System.arraycopy(elements, 0, list, 0, elements.length);
+		return new DoubleList(list);
 	}
 
 	//////////////////////////
@@ -713,6 +720,11 @@ public class DoubleList extends NumberList {
 	@Override
 	protected ListImpl flatten() {
 		return copy();
+	}
+	
+	@Override
+	public List permutations() {
+		return Permutations.allPermutations(_list);
 	}
 	
 	@Override

--- a/src/aya/obj/list/numberlist/NumberItemList.java
+++ b/src/aya/obj/list/numberlist/NumberItemList.java
@@ -11,6 +11,7 @@ import aya.obj.Obj;
 import aya.obj.list.List;
 import aya.obj.list.ListAlgorithms;
 import aya.obj.list.ListImpl;
+import aya.obj.list.Permutations;
 import aya.obj.number.Num;
 import aya.obj.number.Number;
 import aya.obj.number.NumberMath;
@@ -606,6 +607,11 @@ public class NumberItemList extends NumberList {
 	@Override
 	protected ListImpl flatten() {
 		return copy();
+	}
+	
+	@Override
+	public List permutations() {
+		return Permutations.allPermutations(_list);
 	}
 	
 	@Override


### PR DESCRIPTION
New operator `.Z`: generate all permutations of  a list

```
aya> "abc" .Z
[ "abc" "bac" "cab" "acb" "bca" "cba" ] 
aya> [1 2 3] .Z
[
  [ 1 2 3 ]
  [ 2 1 3 ]
  [ 3 1 2 ]
  [ 1 3 2 ]
  [ 2 3 1 ]
  [ 3 2 1 ]
] 
aya> [1 'a {}] .Z
[
  [ 1 'a {} ]
  [ 'a 1 {} ]
  [ {} 1 'a ]
  [ 1 {} 'a ]
  [ 'a {} 1 ]
  [ {} 'a 1 ]
] 
```