### PR TITLE
fix docs for regex replace operator (.&)

### DIFF
--- a/src/aya/instruction/op/DotOps.java
+++ b/src/aya/instruction/op/DotOps.java
@@ -357,7 +357,7 @@ class OP_Dot_And extends OpInstruction {
 
 	public OP_Dot_And() {
 		init(".&");
-		arg("SSS", "replace all occurances of the regex S1 with S2 in S3");
+		arg("SSS", "replace all occurrences of the regex S2 with S3 in S1");
 		arg("LLB", "zip with");
 		arg("SNN|LNN|NNN", "convert base of N|S|L from N1 to N2");
 	}


### PR DESCRIPTION
It seems this commit changed the order of arguments without updating the docs.
https://github.com/aya-lang/aya/commit/ff1a162094ba3fa784e7292fce3f13ee15250af2

Usages like https://github.com/aya-lang/aya/blob/53542a60a22de71af90e81ca66eed560722d7ea1/base/importlib.aya#L74
were updated though, so I'm assuming it's *just* the docs that are wrong.