### PR TITLE
Refactor FileSystem handling (fix absolute paths on Windows)

### DIFF
--- a/src/aya/AyaPrefs.java
+++ b/src/aya/AyaPrefs.java
@@ -107,23 +107,7 @@ public class AyaPrefs {
 			return false;
 		}
 	}
-	
-	public static ArrayList<String> listFilesForWorkingDir() {
-		return listFilesForFolder(new File(getWorkingDir()));
-	}
-	
-	public static ArrayList<String> listFilesForFolder(final File folder) {
-		File[] listOfFiles = folder.listFiles();
-		ArrayList<String> fileList = new ArrayList<String>();
-		for (File file : listOfFiles) {
-		    if (file.isFile()) {
-		        fileList.add(file.getName());
-		    } 
-		}
-		return fileList;
-	}
-	
-	
+
 	public static ArrayList<String> listFilesAndDirsForFolder(final File folder) {
 		File[] listOfFiles = folder.listFiles();
 		ArrayList<String> fileList = new ArrayList<String>();
@@ -153,14 +137,9 @@ public class AyaPrefs {
 		return true;
 	}
 	
-	public static boolean deleteFile(String filename) {
-		Path path = new File(filename).toPath();
+	public static boolean deleteFile(File file) {
 		try {
-		    Files.delete(path);
-		} catch (NoSuchFileException x) {
-			return false;
-		} catch (DirectoryNotEmptyException x) {
-			return false;
+		    Files.delete(file.toPath());
 		} catch (IOException x) {
 			return false;
 		}

--- a/src/aya/InteractiveAya.java
+++ b/src/aya/InteractiveAya.java
@@ -1,5 +1,6 @@
 package aya;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.PrintStream;
 import java.util.NoSuchElementException;
@@ -320,7 +321,7 @@ public class InteractiveAya extends Thread {
 				String code = argCode(args,	2);
 				
 				try {
-					String script = (code + "\n" + FileUtils.readAllText(filename)).trim();
+					String script = (code + "\n" + FileUtils.readAllText(new File(filename))).trim();
 					
 					// Is there a shebang? If yes, drop the first line
 					if (script.charAt(0) == '#' && script.charAt(1) == '!') {

--- a/src/aya/ext/graphics/instruction/SaveGraphicsInstruction.java
+++ b/src/aya/ext/graphics/instruction/SaveGraphicsInstruction.java
@@ -23,8 +23,7 @@ public class SaveGraphicsInstruction extends GraphicsInstruction {
 		String filename = _reader.popString();
 		
 		try {
-			File f = new File(FileUtils.workingRelative(filename));
-			cvs.save(f);
+			cvs.save(FileUtils.resolveFile(filename));
 		} catch (IOException e) {
 			block.push(Num.ZERO);
 		}

--- a/src/aya/ext/plot/FreeChartInterface.java
+++ b/src/aya/ext/plot/FreeChartInterface.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 
 import javax.swing.JFrame;
 
+import aya.util.FileUtils;
 import org.jfree.chart.ChartFactory;
 import org.jfree.chart.ChartPanel;
 import org.jfree.chart.ChartUtilities;
@@ -24,7 +25,6 @@ import org.jfree.data.xy.XYSeries;
 import org.jfree.data.xy.XYSeriesCollection;
 import org.jfree.ui.RefineryUtilities;
 
-import aya.AyaPrefs;
 import aya.exceptions.runtime.IOError;
 import aya.exceptions.runtime.TypeError;
 import aya.exceptions.runtime.ValueError;
@@ -94,21 +94,18 @@ public class FreeChartInterface
 		// Save chart
 		String filename = d.getString(sym("filename"), "");
 		if (!filename.equals("")) {
-			String path = AyaPrefs.getWorkingDir() + filename;
-			File file;
+			File exportFile = FileUtils.resolveFile(filename);
 			try {
-				if (path.contains(".png")) {
-					file = new File(path); 
-					ChartUtilities.saveChartAsPNG(file, chart, width, height);
-				} else if (path.contains(".jpg")) {
-					file = new File(path); 
-					ChartUtilities.saveChartAsJPEG(file, chart, width, height);
+				if (filename.toLowerCase().endsWith(".png")) {
+					ChartUtilities.saveChartAsPNG(exportFile, chart, width, height);
+				} else if (filename.toLowerCase().endsWith(".jpg")) {
+					ChartUtilities.saveChartAsJPEG(exportFile, chart, width, height);
 				} else {
 					throw new ValueError("Plot: Please specify either '*.png' ot '*.jpg' in the filename\n"
 							+ "Received: " + filename);
 				}
 			} catch (IOException e) {
-				throw new IOError("plot", path, e);
+				throw new IOError("plot", exportFile.getAbsolutePath(), e);
 			}
 		}
 		

--- a/src/aya/ext/sys/SystemInstructionStore.java
+++ b/src/aya/ext/sys/SystemInstructionStore.java
@@ -133,9 +133,9 @@ public class SystemInstructionStore extends NamedInstructionStore {
 					if(arg_str.equals("")) {
 						throw new ValueError(":{sys.rm} : arg must be a valid name. Received:\n" + arg_str);
 					}
-					String fstr = AyaPrefs.getWorkingDir() + arg.str();
-					if(!AyaPrefs.deleteFile(fstr)) {
-						throw new ValueError(":{sys.rm} : arg must be a valid name. Received:\n" + fstr);
+					File delFile = FileUtils.resolveFile(arg.str());
+					if(!AyaPrefs.deleteFile(delFile)) {
+						throw new ValueError(":{sys.rm} : arg must be a valid name. Received:\n" + delFile.getAbsolutePath());
 					}
 				} else {
 					throw new ValueError(":{sys.rm} : arg must be a string. Received:\n" + arg.repr());

--- a/src/aya/instruction/op/DotOps.java
+++ b/src/aya/instruction/op/DotOps.java
@@ -17,6 +17,7 @@ import static aya.util.Casting.asNumberList;
 import static aya.util.Casting.asStr;
 import static aya.util.Casting.asSymbol;
 
+import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
@@ -64,6 +65,7 @@ import aya.obj.symbol.SymbolConstants;
 import aya.parser.Parser;
 import aya.parser.ParserString;
 import aya.util.Casting;
+import aya.util.FileUtils;
 import aya.util.VectorizedFunctions;
 
 public class DotOps {
@@ -1019,26 +1021,27 @@ class OP_Dot_Write extends OpInstruction {
 			final int option = ((Number)n).toInt();
 			final String filename = s.str();
 			final String write = a.str();
-			final String fstr = AyaPrefs.getWorkingDir()+filename;
+			final File file = FileUtils.resolveFile(filename);
+			final String absFilePath = file.getAbsolutePath();
 
 
 			if(option == 0) {
 				try {
-				    Files.write(Paths.get(fstr), write.getBytes(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+				    Files.write(file.toPath(), write.getBytes(), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
 				}catch (IOException e) {
-				    throw new IOError(".G", fstr, e);
+				    throw new IOError(".G", absFilePath, e);
 				} catch (InvalidPathException ipe) {
-				    throw new IOError(".G", fstr, "Invalid path");
+				    throw new IOError(".G", absFilePath, "Invalid path");
 				}
 			}
 
 			else if (option == 1) {
 				try {
-				    Files.write(Paths.get(fstr), write.getBytes(), StandardOpenOption.CREATE, StandardOpenOption.APPEND);
+				    Files.write(file.toPath(), write.getBytes(), StandardOpenOption.CREATE, StandardOpenOption.APPEND);
 				}catch (IOException e) {
-				    throw new IOError(".G", fstr, e);
+				    throw new IOError(".G", absFilePath, e);
 				} catch (InvalidPathException ipe) {
-				    throw new IOError(".G", fstr, "Invalid path");
+				    throw new IOError(".G", absFilePath, "Invalid path");
 				}
 			}
 

--- a/src/aya/instruction/op/Ops.java
+++ b/src/aya/instruction/op/Ops.java
@@ -66,7 +66,7 @@ import aya.util.VectorizedFunctions;
 public class Ops {
 	
 	public static final Random RAND = new Random((new Date()).getTime());
-	public static final Pattern PATTERN_URL = Pattern.compile("http:\\/\\/.*|https:\\/\\/.*");
+	public static final Pattern PATTERN_URL = Pattern.compile("https?://.*");
 
 	
 	////////////////////////
@@ -918,18 +918,18 @@ class OP_G extends OpInstruction {
 	@Override
 	public void execute (final Block block) {
 		final Obj a = block.pop();
-		
-		
+
+
 		if(a.isa(STR)) {
 			String name = a.str();
-			
+
 			if(Ops.PATTERN_URL.matcher(name).matches()) {
 				Scanner scnr = null;
 				try {
 					URL url = new URL(name);
 					scnr = new Scanner(url.openStream());
 					StringBuilder sb = new StringBuilder();
-					
+
 					while(scnr.hasNext()) {
 						sb.append(scnr.nextLine()).append('\n');
 					}
@@ -942,19 +942,13 @@ class OP_G extends OpInstruction {
 						scnr.close();
 				}
 			} else {
-				String path = "";
-				if (name.charAt(0) == '/' || name.contains(":\\") || name.contains(":/")) {
-					path = name;
-				} else {
-					path = AyaPrefs.getWorkingDir() + name;
-				}
+				File readFile = FileUtils.resolveFile(name);
 				try {
-					block.push( List.fromString(FileUtils.readAllText(path)) );
+					block.push( List.fromString(FileUtils.readAllText(readFile)) );
 				} catch (IOException e) {
-					throw new IOError("G", new File(path).getAbsolutePath(), e);
-				} 
+					throw new IOError("G", readFile.getAbsolutePath(), e);
+				}
 			}
-			return;
 		} else if (a.isa(NUMBER)) {
 			block.push( Num.fromBool(((Number)a).isPrime()) );
 		} else {

--- a/src/aya/util/FileUtils.java
+++ b/src/aya/util/FileUtils.java
@@ -1,53 +1,30 @@
 package aya.util;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
-
 import aya.AyaPrefs;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+
 public class FileUtils {
-	
+
 	@SuppressWarnings("null")
-	public static String readAllText(String path) throws IOException {
-		File file = new File(path);
-		BufferedReader br = null;
-		StringBuilder sb = new StringBuilder();
-		
-		try {
-			String line;
-			br = new BufferedReader(new InputStreamReader(new FileInputStream(file), StandardCharsets.UTF_8));
-			while((line = br.readLine()) != null) {
-				sb.append(line+'\n');
-			}
-		} catch (IOException e) {
-			try {
-				br.close();
-			} catch (NullPointerException e2) {}
-			throw e;
-		}
-		
-		br.close();
-		return sb.toString();
+	public static String readAllText(File file) throws IOException {
+		return new String(Files.readAllBytes(file.toPath()), StandardCharsets.UTF_8); // in Java 11 you can also do Files.readString(Path)
 	}
 
-	public static String pathAppend(String dir1, String dir2) {
-		return dir1 + File.separator + dir2;
-	}
-	
-	public static String workingRelative(String dir) {
-		if (dir.startsWith("/") || dir.startsWith("C:")) {
-			return dir;
-		} else {
-			return pathAppend(AyaPrefs.getWorkingDir(), dir);
-		}
+	/**
+	 * Resolves a pathName to a File, either relative to the current {@link AyaPrefs#getWorkingDir()} or absolute.
+	 * <p> Absolute pathNames are handled based on the Operating System
+	 */
+	public static File resolveFile(String pathName) {
+		File file = new File(pathName);
+		return file.isAbsolute() ? file : new File(AyaPrefs.getWorkingDir(), pathName);
 	}
 
 	public static boolean isFile(String str) {
-		return new File(str).isFile();
+		return resolveFile(str).isFile();
 	}
 	
 	public static String resolveHome(String path) {


### PR DESCRIPTION
I noticed that while `G` works great, `.G` does not.
Example: `"C:\abs\file.txt" :& G \ "_2"+ 0 .G` (which should copy the file content into `C:\abs\file.txt_2`)
instead results in
```
io_err at .G: unable to use resource D:\tools\Aya\bin_v4_rc1\C:\abs\file.txt_2. Invalid path
   in .G .. }
```

So I had a look at all the uses of AyaPrefs.getWorkingDir() and updated those.

**Tests**
```
.# Windows Tests
"C:/abs/test.txt" :& G \ "_2"+ 0 .G       .# correctly copies from C:/abs/test.txt     to C:/abs/test.txt_2        preserving \r\n
"test.txt"        :& G \ "_2"+ 0 .G       .# correctly copies from <workDir>/test.txt  to <workDir>/test.txt_2 preserving \r\n
"/test.txt"       :& G \ "_2"+ 0 .G       .# behaves identical to "test.txt" on Windows (good)

.# WSL Ubuntu Tests
"C:/abs/test.txt"     :& G \ "_2"+ 0 .G   .# io_err at G: unable to use resource /mnt/c/tools/Aya/bin_v4_rc1/C:/abs/test.txt (good)
"test.txt"            :& G \ "_2"+ 0 .G   .# correctly copies from <workDir>/test.txt  to <workDir>/test.txt_2
"/mnt/c/abs/test.txt" :& G \ "_3"+ 0 .G   .# correctly copies from C:/abs/test.txt     to C:/abs/test.txt_2
```
`:{sys.file_exists}` also behaves as expected.
I did not test SaveGraphicsInstruction, Plots and File-Deletion (seems reasonable to assume that these will operate correctly)