### PR TITLE
Allow sorting Strings with OP_Dot_SortUsing

### DIFF
--- a/src/aya/instruction/op/DotOps.java
+++ b/src/aya/instruction/op/DotOps.java
@@ -884,11 +884,16 @@ class OP_Dot_SortUsing extends Operator {
 			List key_obj = ListIterationFunctions.map(blockEvaluator.getContext(), objs, blk);
 
 			//Convert keys to int array
-			ArrayList<SUItem> items = new ArrayList<SUItem>(key_obj.length());
+			ArrayList<SUItem> items = new ArrayList<>(key_obj.length());
 			try {
 
 				for (int i = 0; i < objs.length(); i++) {
-					items.add(new SUItem(objs.getExact(i), (Comparable) key_obj.getExact(i)));
+					Obj item = key_obj.getExact(i);
+					if (item.isa(STR)) {
+						items.add(new SUItem(objs.getExact(i), item.str()));
+					} else {
+						items.add(new SUItem(objs.getExact(i), (Comparable) item));
+					}
 				}
 				Collections.sort(items);
 


### PR DESCRIPTION
I've noticed that `["c" "a" "b"] C` works
however `["c" "a" "b"] {} .C` didn't work.

Attempting to sort different key types still results in the correct error:
```
.C: all objects must be comparable to each other


["c" "a" 2] {} .C
~~~~~~~~~~~~~~~~^
Function call traceback:
```