### PR TITLE
Fix StartupScript-Paths containing escape sequences failing on Windows

### DIFF
--- a/src/aya/InteractiveAya.java
+++ b/src/aya/InteractiveAya.java
@@ -171,7 +171,7 @@ public class InteractiveAya {
 		// Load startup script
 		String[] args = AyaPrefs.getArgs();
 		if (args.length >= 2 && args[1].contains(".aya")) {
-			String startupScript = AyaPrefs.getArgs()[1];
+			String startupScript = AyaPrefs.getArgs()[1].replace("\\", "\\\\");
 			StaticBlock blk2 = Parser.compileSafeOrNull(new SourceString("\"" + startupScript + "\":F", "<ayarc loader>"), StaticData.IO);
 			if (blk2 != null) {
 				_aya.queueInput(new ExecutionRequest(makeRequestID(), blk2));


### PR DESCRIPTION
While trying to run aya-digit on Windows I got a funny Error.

```
io_err at :F: unable to use resource D:\aya
orks\aya-digit\interactive.aya. Illegal char <
```
For my path `D:\aya\forks\aya-digit\`

---

All other manually created `:F` instructions seem to handle this correctly already, so I just mirrored that.