### PR TITLE
Fix File-resolution on Windows

### DIFF
--- a/src/aya/AyaPrefs.java
+++ b/src/aya/AyaPrefs.java
@@ -4,13 +4,13 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.util.ArrayList;
 
 import aya.obj.Obj;
 import aya.obj.character.Char;
 import aya.obj.list.Str;
 import aya.obj.number.Num;
+import aya.util.FileUtils;
 
 public class AyaPrefs {
 	private static String prompt = "aya> ";
@@ -63,10 +63,8 @@ public class AyaPrefs {
 			dir += File.separator;
 		}
 		try {
-			//Create a path to test if it exists
-			File fwd = new File(dir);
-			Path path = new File(dir).toPath();
-			if (Files.exists(path)) {
+			File fwd = FileUtils.resolveFile(dir);
+			if (fwd.exists()) {
 				return fwd.getCanonicalPath() + File.separator;
 			} else {
 				//System.out.println("setWorkingDir: error, dir does not exist: " + workingDir);
@@ -116,7 +114,7 @@ public class AyaPrefs {
 	}
 	
 	public static boolean mkDir(String dirName) {
-		File theDir = new File(dirName);
+		File theDir = FileUtils.resolveFile(dirName);
 
 		// if the directory does not exist, create it
 		if (!theDir.exists()) {

--- a/src/aya/AyaPrefs.java
+++ b/src/aya/AyaPrefs.java
@@ -107,7 +107,7 @@ public class AyaPrefs {
 		    if (file.isFile()) {
 		        fileList.add(file.getName());
 		    } else if (file.isDirectory()) {
-		    	fileList.add(File.separator + file.getName());
+		    	fileList.add(file.getName() + File.separator);
 		    }
 		}
 		return fileList;

--- a/src/aya/ext/fstream/FStreamManager.java
+++ b/src/aya/ext/fstream/FStreamManager.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.stream.Collectors;
 
 import aya.StaticData;
+import aya.util.FileUtils;
 
 public class FStreamManager {
 	
@@ -50,7 +51,7 @@ public class FStreamManager {
 		boolean valid = false;
 		
 		try {
-			File file = new File(filename);
+			File file = FileUtils.resolveFile(filename);
 			FileReader fr = new FileReader(file);
 			f = new BufferedReader(fr);
 			valid = true;
@@ -73,7 +74,7 @@ public class FStreamManager {
 		boolean valid = false;
 		
 		try {
-			File file = new File(filename);
+			File file = FileUtils.resolveFile(filename);
 			FileOutputStream fos = new FileOutputStream(file, type == 'a');
 			pw = new PrintWriter(fos);
 			valid = true;
@@ -140,23 +141,7 @@ public class FStreamManager {
 			return -1;
 		}
 	}
-	
-	public static String readAll(String path) throws IOException {
-		File file = new File(path);
-		String output = null;
-		BufferedReader br = null;
-		try {
-			br = new BufferedReader(new FileReader(file));
-			output = br.lines().collect(Collectors.joining("\n"));
-			br.close();
-		} catch (IOException e) {
-			br.close();
-			output = null;
-		}
-		
-		return output;
-	}
-	
+
 	public static String readAll(int fileid) {
 		BufferedReader f = _input_streams.get(fileid);
 		if (f == null) return null;

--- a/src/aya/ext/image/ReadImageInstruction.java
+++ b/src/aya/ext/image/ReadImageInstruction.java
@@ -11,6 +11,7 @@ import aya.exceptions.runtime.IOError;
 import aya.exceptions.runtime.TypeError;
 import aya.instruction.named.NamedOperator;
 import aya.obj.Obj;
+import aya.util.FileUtils;
 
 public class ReadImageInstruction extends NamedOperator {
 	
@@ -41,11 +42,11 @@ public class ReadImageInstruction extends NamedOperator {
 		blockEvaluator.push(image.toDict());
 	}
 
-	public AyaImage loadImage(String ImageName) throws IOException {
-		 // open image
-		 File imgPath = new File(ImageName);
-		 BufferedImage bufferedImage = ImageIO.read(imgPath);
-		 return AyaImage.fromBufferedImage(bufferedImage);
+	public AyaImage loadImage(String imageName) throws IOException {
+		// open image
+		File imgFile = FileUtils.resolveFile(imageName);
+		BufferedImage bufferedImage = ImageIO.read(imgFile);
+		return AyaImage.fromBufferedImage(bufferedImage);
 	}		
 
 }

--- a/src/aya/ext/image/WriteImageInstruction.java
+++ b/src/aya/ext/image/WriteImageInstruction.java
@@ -1,6 +1,5 @@
 package aya.ext.image;
 
-import java.io.File;
 import java.io.IOException;
 
 import javax.imageio.ImageIO;
@@ -14,6 +13,7 @@ import aya.obj.Obj;
 import aya.obj.dict.Dict;
 import aya.obj.symbol.SymbolTable;
 import aya.util.DictReader;
+import aya.util.FileUtils;
 
 public class WriteImageInstruction extends NamedOperator {
 	
@@ -43,7 +43,7 @@ public class WriteImageInstruction extends NamedOperator {
 		AyaImage aya_image = AyaImage.fromDict(dr);
 		
 		try {
-			ImageIO.write(aya_image.toBufferedImage(), ext, new File(filename));
+			ImageIO.write(aya_image.toBufferedImage(), ext, FileUtils.resolveFile(filename));
 		} catch (IOException e) {
 			throw new IOError(opName(), filename, e);
 		} catch (IllegalArgumentException e) {

--- a/src/aya/ext/sys/SystemInstructionStore.java
+++ b/src/aya/ext/sys/SystemInstructionStore.java
@@ -29,7 +29,7 @@ public class SystemInstructionStore extends NamedInstructionStore {
 				if (arg.isa(Obj.STR)) {
 					String fstr = arg.str();
 					try {
-						ArrayList<String> dirs = AyaPrefs.listFilesAndDirsForFolder(new File(fstr));
+						ArrayList<String> dirs = AyaPrefs.listFilesAndDirsForFolder(FileUtils.resolveFile(fstr));
 						ArrayList<Obj> obj_dirs = new ArrayList<Obj>(dirs.size());
 						for (String s : dirs) {
 							obj_dirs.add(List.fromString(s));

--- a/test/filesystem.aya
+++ b/test/filesystem.aya
@@ -1,0 +1,81 @@
+.# Run inside aya directory
+.#
+.# cd path/to/aya
+.# rm -rf fs_test
+.# mkdir fs_test
+.# java -jar aya.jar fs_test/ ../test/filesystem.aya
+
+.# Create a directory
+"dir1" :{sys.mkdir}
+{"." :{sys.readdir} ["dir1/"] = 1} test.test
+
+.# Change working directory
+"dir1" :{sys.cd}
+"dir2" :{sys.mkdir}
+{"." :{sys.readdir} ["dir2/"] = 1} test.test
+
+".." :{sys.cd}
+{"." :{sys.readdir} ["dir1/"] = 1} test.test
+
+"../../" :{sys.set_ad}
+"../" :{sys.cd}
+{"fs_test" :{sys.readdir} ["dir1/"] = 1} test.test
+
+.# Set aya dir back to normal
+"." :{sys.set_ad}
+"fs_test" :{sys.cd}
+{"." :{sys.readdir} ["dir1/"] = 1} test.test
+"dir1" :{sys.cd}
+{"." :{sys.readdir} ["dir2/"] = 1} test.test
+
+.# Return to aya dir
+"" :{sys.cd}
+.# Go into fs_test dir
+"fs_test" :{sys.cd}
+{"." :{sys.readdir} ["dir1/"] = 1} test.test
+
+.# cd into nested directory
+"dir1/dir2/" :{sys.cd}
+{"." :{sys.readdir} [] = 1} test.test
+"../.." :{sys.cd}
+{"." :{sys.readdir} ["dir1/"] = 1} test.test
+
+
+.# Write a file
+"hello.txt" 'w :{fstream.O} :id;
+{"Hello!" id :{fstream.O} 1} test.test
+{id 'c :{fstream.O} 1} test.test
+.# Use C to sort lists when checking if they are equal
+{"." :{sys.readdir}C ["dir1/" "hello.txt"]C = 1} test.test
+
+.# Read a file
+"hello.txt" 'r :{fstream.O} :id;
+{id 'a :{fstream.O} "Hello!"} test.test
+{id 'c :{fstream.O} 1} test.test
+
+
+.# Write a file in a directory
+"dir1/two-plus-two.txt" 'w :{fstream.O} :id;
+{"four" id :{fstream.O} 1} test.test
+{id 'c :{fstream.O} 1} test.test
+.# Use C to sort lists when checking if they are equal
+{"." :{sys.readdir}C ["dir1/" "hello.txt"]C = 1} test.test
+{"dir1/" :{sys.readdir}C ["dir2/" "two-plus-two.txt"]C = 1} test.test
+
+.# Read a file in a directory
+"dir1/two-plus-two.txt" 'r :{fstream.O} :id;
+{id 'a :{fstream.O} "four"} test.test
+{id 'c :{fstream.O} 1} test.test
+
+.# Create a directory in a directory
+"dir1/dir2/dir3" :{sys.mkdir}
+{"dir1/dir2" :{sys.readdir} ["dir3/"] = 1} test.test
+
+.# Create a single pixel image
+{, 1:width 1:height "out.png":filename [41 -92 34]:data }:img;
+img :{image.write}
+{"." :{sys.readdir}C ["dir1/" "hello.txt" "out.png"]C = 1} test.test
+
+.# Read an image
+"out.png" :{image.read} :img;
+{img {, 1:width 1:height [41 -92 34]:data }} test.test

--- a/test/filesystem.aya
+++ b/test/filesystem.aya
@@ -5,40 +5,43 @@
 .# mkdir fs_test
 .# java -jar aya.jar fs_test/ ../test/filesystem.aya
 
+.{ Function that appends the platform-specific file separator to a string .}
+{path::str, path :9s + } :sep;
+
 .# Create a directory
 "dir1" :{sys.mkdir}
-{"." :{sys.readdir} ["dir1/"] = 1} test.test
+{"." :{sys.readdir} ["dir1"sep] = 1} test.test
 
 .# Change working directory
 "dir1" :{sys.cd}
 "dir2" :{sys.mkdir}
-{"." :{sys.readdir} ["dir2/"] = 1} test.test
+{"." :{sys.readdir} ["dir2"sep] = 1} test.test
 
 ".." :{sys.cd}
-{"." :{sys.readdir} ["dir1/"] = 1} test.test
+{"." :{sys.readdir} ["dir1"sep] = 1} test.test
 
 "../../" :{sys.set_ad}
 "../" :{sys.cd}
-{"fs_test" :{sys.readdir} ["dir1/"] = 1} test.test
+{"fs_test" :{sys.readdir} ["dir1"sep] = 1} test.test
 
 .# Set aya dir back to normal
 "." :{sys.set_ad}
 "fs_test" :{sys.cd}
-{"." :{sys.readdir} ["dir1/"] = 1} test.test
+{"." :{sys.readdir} ["dir1"sep] = 1} test.test
 "dir1" :{sys.cd}
-{"." :{sys.readdir} ["dir2/"] = 1} test.test
+{"." :{sys.readdir} ["dir2"sep] = 1} test.test
 
 .# Return to aya dir
 "" :{sys.cd}
 .# Go into fs_test dir
 "fs_test" :{sys.cd}
-{"." :{sys.readdir} ["dir1/"] = 1} test.test
+{"." :{sys.readdir} ["dir1"sep] = 1} test.test
 
 .# cd into nested directory
 "dir1/dir2/" :{sys.cd}
 {"." :{sys.readdir} [] = 1} test.test
 "../.." :{sys.cd}
-{"." :{sys.readdir} ["dir1/"] = 1} test.test
+{"." :{sys.readdir} ["dir1"sep] = 1} test.test
 
 
 .# Write a file
@@ -46,7 +49,7 @@
 {"Hello!" id :{fstream.O} 1} test.test
 {id 'c :{fstream.O} 1} test.test
 .# Use C to sort lists when checking if they are equal
-{"." :{sys.readdir}C ["dir1/" "hello.txt"]C = 1} test.test
+{"." :{sys.readdir}C ["dir1"sep "hello.txt"]C = 1} test.test
 
 .# Read a file
 "hello.txt" 'r :{fstream.O} :id;
@@ -59,8 +62,8 @@
 {"four" id :{fstream.O} 1} test.test
 {id 'c :{fstream.O} 1} test.test
 .# Use C to sort lists when checking if they are equal
-{"." :{sys.readdir}C ["dir1/" "hello.txt"]C = 1} test.test
-{"dir1/" :{sys.readdir}C ["dir2/" "two-plus-two.txt"]C = 1} test.test
+{"." :{sys.readdir}C ["dir1"sep "hello.txt"]C = 1} test.test
+{"dir1/" :{sys.readdir}C ["dir2"sep "two-plus-two.txt"]C = 1} test.test
 
 .# Read a file in a directory
 "dir1/two-plus-two.txt" 'r :{fstream.O} :id;
@@ -69,12 +72,12 @@
 
 .# Create a directory in a directory
 "dir1/dir2/dir3" :{sys.mkdir}
-{"dir1/dir2" :{sys.readdir} ["dir3/"] = 1} test.test
+{"dir1/dir2" :{sys.readdir} ["dir3"sep] = 1} test.test
 
 .# Create a single pixel image
 {, 1:width 1:height "out.png":filename [41 -92 34]:data }:img;
 img :{image.write}
-{"." :{sys.readdir}C ["dir1/" "hello.txt" "out.png"]C = 1} test.test
+{"." :{sys.readdir}C ["dir1"sep "hello.txt" "out.png"]C = 1} test.test
 
 .# Read an image
 "out.png" :{image.read} :img;


### PR DESCRIPTION
While trying to use aya-digit I noticed that `"model.json" json.load` fails on windows.

I've used `FileUtils.resolveFile` where it seemed appropriate. (relates to #93 )

I initially thought this fix only applied to windows, but after testing on Ubuntu, it appears Aya also behaves oddly on Linux?
**(Stop me if the assumptions in my tests are just plain wrong)**

The primary cause of Linux weirdness seems to come from my shell having a different working directory than the one I pass to Aya.
'Actual output' indicates the behaviour I am seeing with the current Version of Aya.
'Expected output' is the behaviour using the changes of this PR.

---

## Tests / Affected Instructions

### `sys.cd`, `sys.mkdir`

test.aya:
```
"dir1" :{sys.mkdir}
"./dir1" :{sys.cd}
"dir2" :{sys.mkdir}
```
`~/dir3$ java -jar /path/to/aya.jar /path/to/test /path/to/test/test.aya`

Expected new directories:
- `/path/to/test/dir1/dir2`

Actual new directories:
- `~/dir3/dir1`
- `~/dir3/dir2`

---

### `sys.set_ad`, `sys.readdir`

test.aya
```
"../../" :{sys.set_ad}
"../" :{sys.cd}
"." :{sys.readdir}
"" :{sys.cd}           .# reset working directory to aya directory
"." :{sys.readdir}
```
`~/dir3$ java -jar /path/to/aya.jar /path/to/test /path/to/test/test.aya`

Expected output:
- list of files in `/path/to/`
- list of files in `/path/`

Actual output:
- list of files in `~/dir3`
- list of files in `~/dir3`

---

### `fstream.O`

test.aya
```
"data.json" 'r :{fstream.O} :id
id 'a :{fstream.O}
```
`~/dir3$ echo "{\"hello\":123,\"world\":456}" > /path/to/test/data.json`
`~/dir3$ java -jar /path/to/aya.jar /path/to/test /path/to/test/test.aya`

Expected output: `11 "{\"hello\":123,\"world\":456}"`

Actual output: `0 0` (failed to read file)

---

### `image.read` and `image.write`

test.aya
```
"in.png" :{image.read} :img
"out.png" img.:filename;
img :{image.write}
```
`echo "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAADElEQVQI12NQWqIJAAHbAPCVVqDlAAAAAElFTkSuQmCC" | base64 -d > /path/to/test/in.png`
`~/dir3$ java -jar /path/to/aya.jar /path/to/test /path/to/test/test.aya`

Expected output:
```
{,
  1:width;
  1:height;
  "out.png":filename;
  [ 41 -92 34 ]:data;
}
```
and `/path/to/test/out.png` is created.

Actual output:
```
io_err at :{image.read}: unable to use resource in.png. Can't read input file!


> File '/path/to/test/test.aya', line 1, col 22:
1 | "in.png" :{image.read} :img
    ~~~~~~~~~~~~~~~~~~~~~^
2 | "out.png" img.:filename;

Function call traceback:
```