### PR TITLE
Broadcasting rules are properly applied to length 1 `NumberList`s

### DIFF
--- a/src/aya/util/VectorizedFunctions.java
+++ b/src/aya/util/VectorizedFunctions.java
@@ -72,8 +72,18 @@ public class VectorizedFunctions {
 	//
 
 	private static List vectorizeListList(ExecutionContext context, Operator op, List a, List b, NumberListOp nlop) {
-		if (a.isa(NUMBERLIST) && b.isa(NUMBERLIST) && a.length() == b.length()) {
-			return new List(nlop.ll(asNumberList(a), asNumberList(b)));
+		if (a.isa(NUMBERLIST) && b.isa(NUMBERLIST)) {
+			final int a_len = a.length();
+			final int b_len = b.length();
+			if (a_len == b_len) {
+				return new List(nlop.ll(asNumberList(a), asNumberList(b)));
+			} else if (a_len == 1) {
+				return new List(nlop.nl(asNumberList(a).get(0), asNumberList(b)));
+			} else if (b_len == 1) {
+				return new List(nlop.ln(asNumberList(a), asNumberList(b).get(0)));
+			} else {
+				return vectorizeListList(context, op, a, b);
+			}
 		} else {
 			return vectorizeListList(context, op, a, b);
 		}


### PR DESCRIPTION
When updating the broadcasting rules in #97, the rules were not properly applied to the `NumberList` optimized code. This means that if using a `NumberList` it would default to standard single item processing. This would lead to the correct result but be much slower that using the `NumberList` operator.

This update adds the additional cases to the numberlist optimization.

When testing broadcasting across arrays with a shape of `[3 35000]` this fix led to a **~100x speedup**.