### PR TITLE
Add graphics instruction for drawing a batch of points

### DIFF
--- a/src/aya/ext/graphics/GraphicsInstructionStore.java
+++ b/src/aya/ext/graphics/GraphicsInstructionStore.java
@@ -1,6 +1,7 @@
 package aya.ext.graphics;
 
 import aya.ext.graphics.instruction.ArcGraphicsInstruction;
+import aya.ext.graphics.instruction.PointsGraphicsInstruction;
 import aya.ext.graphics.instruction.ClearGraphicsInstruction;
 import aya.ext.graphics.instruction.ClearRectGraphicsInstruction;
 import aya.ext.graphics.instruction.CloseGraphicsInstruction;
@@ -50,6 +51,7 @@ public class GraphicsInstructionStore extends NamedInstructionStore {
 		addInstruction(new ClickEventsInstruction(canvas_table));
 		addInstruction(new CloseGraphicsInstruction(canvas_table));
 		addInstruction(new CopyRectGraphicsInstruction(canvas_table));
+		addInstruction(new PointsGraphicsInstruction(canvas_table));
 		addInstruction(new EllipseGraphicsInstruction(canvas_table));
 		addInstruction(new GetPixelsGraphicsInstruction(canvas_table));
 		addInstruction(new IsOpenGraphicsInstruction(canvas_table));

--- a/src/aya/ext/graphics/instruction/PointsGraphicsInstruction.java
+++ b/src/aya/ext/graphics/instruction/PointsGraphicsInstruction.java
@@ -1,0 +1,50 @@
+package aya.ext.graphics.instruction;
+
+import aya.eval.BlockEvaluator;
+import aya.exceptions.runtime.IndexError;
+import aya.ext.graphics.Canvas;
+import aya.ext.graphics.CanvasTable;
+import aya.ext.graphics.GraphicsInstruction;
+import aya.obj.Obj;
+import aya.obj.list.List;
+import aya.obj.list.numberlist.NumberList;
+import aya.util.Casting;
+
+public class PointsGraphicsInstruction extends GraphicsInstruction {
+
+	public PointsGraphicsInstruction(CanvasTable canvas_table) {
+		super(canvas_table, "points", "LNNN");
+		_doc = "points width height canvas_id: draw a batch of points";
+	}
+	
+
+	@Override
+	protected void doCanvasCommand(Canvas cvs, BlockEvaluator blockEvaluator) {
+		final int h = _reader.popInt();
+		final int w = _reader.popInt();
+		List points = _reader.popList();
+		
+		final int half_h = h/2;
+		final int half_w = w/2;
+		
+		try {
+			for (int i = 0; i < points.length(); i++) {
+				Obj point_obj = points.getExact(i);
+				if (point_obj.isa(Obj.LIST)) {
+					NumberList point = Casting.asList(points.getExact(i)).toNumberList();
+					int x = point.get(0).toInt();
+					int y = point.get(1).toInt();
+			
+					cvs.getG2D().fillRect(x-half_w, y-half_h, w, h);	
+				}
+			}
+		} catch (IndexOutOfBoundsException e) {
+			throw new IndexError("All points must have length 2");
+		}
+
+		cvs.refresh();
+	}	
+}
+
+
+

--- a/src/aya/util/BlockReader.java
+++ b/src/aya/util/BlockReader.java
@@ -4,6 +4,7 @@ import aya.eval.BlockEvaluator;
 import aya.exceptions.runtime.TypeError;
 import aya.instruction.named.NamedOperator;
 import aya.obj.Obj;
+import aya.obj.list.List;
 import aya.obj.list.numberlist.NumberList;
 import aya.obj.symbol.Symbol;
 
@@ -67,6 +68,15 @@ public class BlockReader {
 			return Casting.asSymbol(o);
 		} else {
 			throw new TypeError(_inst, "J", o);
+		}
+	}
+
+	public List popList() {
+		final Obj o = _block.pop();
+		if (o.isa(Obj.LIST)) {
+			return Casting.asList(o);
+		} else {
+			throw new TypeError(_inst, "L", o);
 		}
 	}
 }

--- a/std/canvas.aya
+++ b/std/canvas.aya
@@ -61,6 +61,10 @@ def canvas::fillcircle {x y r self,
     x y r2* $ 1 self.id :{graphics.ellipse}
 }
 
+def canvas::points {points r self,
+    points r2* $ self.id :{graphics.points}
+}
+
 def canvas::set_color {color self,
     .# ::set_color {, color.r:r color.g:g color.b:b } self.id :{graphics.MG} ;
     color.r color.g color.b self.id :{graphics.set_color}


### PR DESCRIPTION
Add a graphics instruction for drawing a batch of points. This instruction gives roughly a 5-7x speedup over looping through each point individually. 

With this instruction we can render all 35K points of the Stanford bunny at in 10ms (previously 50ms-70ms)

[Screencast from 2024-11-28 12-29-59.webm](https://github.com/user-attachments/assets/660ba2fe-30d4-4edf-9344-cd22f763ddc9)
