### PR TITLE
Build restructure option 2 : optional execution using profiles

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,20 +64,6 @@
                             </target>
                         </configuration>
                     </execution>
-                    <execution>
-                        <id>release-zip</id>
-                        <phase>verify</phase>
-                        <goals>
-                            <goal>run</goal>
-                        </goals>
-                        <configuration>
-                            <target>
-                                <property name="build-dir" value="${project.build.directory}"/>
-                                <property name="aya.jar" value="${project.build.directory}/${project.artifactId}-${project.version}.jar"/>
-                                <ant antfile="${project.basedir}/build-scripts/release-zip-build.xml"/>
-                            </target>
-                        </configuration>
-                    </execution>
                 </executions>
             </plugin>
 
@@ -111,6 +97,13 @@
             <artifactId>json</artifactId>
             <version>20231013</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.teavm</groupId>
+            <artifactId>teavm-jso</artifactId>
+            <version>0.10.2</version>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 
 
@@ -124,18 +117,6 @@
             </activation>
             <build>
                 <plugins>
-
-                    <!-- Exclude web specific files -->
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <version>3.13.0</version>
-                        <configuration>
-                            <excludes>
-                                <exclude>web/**</exclude>
-                            </excludes>
-                        </configuration>
-                    </plugin>
 
                     <!-- Build fat JAR -->
                     <plugin>
@@ -157,6 +138,36 @@
                                         </transformer>
                                     </transformers>
                                     <createDependencyReducedPom>false</createDependencyReducedPom>
+
+                                    <!-- exclude teaVM dependency from desktop jar -->
+                                    <artifactSet>
+                                        <excludes>
+                                            <exclude>org.teavm:teavm-classlib</exclude>
+                                        </excludes>
+                                    </artifactSet>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+
+                    <!-- package fat JAR into a release aya.zip -->
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-antrun-plugin</artifactId>
+                        <version>3.1.0</version>
+                        <executions>
+                            <execution>
+                                <id>release-zip</id>
+                                <phase>package</phase>
+                                <goals>
+                                    <goal>run</goal>
+                                </goals>
+                                <configuration>
+                                    <target>
+                                        <property name="build-dir" value="${project.build.directory}"/>
+                                        <property name="aya.jar" value="${project.build.directory}/${project.artifactId}-${project.version}.jar"/>
+                                        <ant antfile="${project.basedir}/build-scripts/release-zip-build.xml"/>
+                                    </target>
                                 </configuration>
                             </execution>
                         </executions>
@@ -226,14 +237,6 @@
 
                 </plugins>
             </build>
-
-            <dependencies>
-                <dependency>
-                    <groupId>org.teavm</groupId>
-                    <artifactId>teavm-jso</artifactId>
-                    <version>0.10.2</version>
-                </dependency>
-            </dependencies>
 
         </profile>
     </profiles>

--- a/src/aya/InteractiveAya.java
+++ b/src/aya/InteractiveAya.java
@@ -180,7 +180,7 @@ public class InteractiveAya {
 		// Load startup script
 		String[] args = AyaPrefs.getArgs();
 		if (args.length >= 2 && args[1].contains(".aya")) {
-			String startupScript = AyaPrefs.getArgs()[1];
+			String startupScript = AyaPrefs.getArgs()[1].replace("\\", "\\\\");
 			StaticBlock blk2 = Parser.compileSafeOrNull(new SourceString("\"" + startupScript + "\":F", "<ayarc loader>"), StaticData.IO);
 			if (blk2 != null) {
 				_aya.queueInput(new ExecutionRequest(makeRequestID(), blk2));

--- a/src/web/AyaWeb.java
+++ b/src/web/AyaWeb.java
@@ -56,7 +56,7 @@ public class AyaWeb {
     	exportRunIsolated(new ExportFunctionRunIsolated() {
 			@Override
 			public String call(String s) {
-				StandaloneAya.runIsolated(input, StaticData.IO);
+				StandaloneAya.runIsolated(s, StaticData.IO);
 		        return output.flushOut() + output.flushErr();
 			}
 		});


### PR DESCRIPTION
This makes building the fat-jar and web files optional.
This also allowed me to move 'creating the release aya.zip' from `verify` into `package` - which seems more standard.
- use `-P !desktop` to just compile / run tests
- use `mvn package` to create `aya.zip`
- use `mvn package -P web` to create `aya.js` and `aya.stdlib.js`
- use `mvn package -P desktop,web` to do both

⚠in direct conflict with #119 (pick one)

---

This also includes some opinionated changes:
- use lambdas instead of anonymous classes in `AyaWeb.java`
- keep the `web/**` files in the fat jar, since they shouldn't cause any issues.