### PR TITLE
Update version to 0.6.0 snapshot

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>co.npaul.aya</groupId>
     <artifactId>aya</artifactId>
-    <version>0.5.0</version>
+    <version>0.6.0-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>11</maven.compiler.source>

--- a/src/aya/StaticData.java
+++ b/src/aya/StaticData.java
@@ -33,7 +33,7 @@ import aya.util.StringSearch;
 public class StaticData {
 
 	public static final boolean DEBUG = true;
-	public static final String VERSION_NAME = "v0.5.0";
+	public static final String VERSION_NAME = "v0.6.0-SNAPSHOT";
 	public static final String ayarcPath = "ayarc.aya";
 	public static final boolean PRINT_LARGE_ERRORS = true;
 	public static final String QUIT = "\\Q";


### PR DESCRIPTION
Since [v0.5.0 is now released](https://github.com/aya-lang/aya/releases/tag/v0.5.0), master will track the development of v0.6.0. I have updated the version strings to use the [maven snapshot convention](https://maven.apache.org/guides/getting-started/#What_is_a_SNAPSHOT_version.3F). 

The version is now `0.6.0-SNAPSHOT`