### PR TITLE
Don't truncate string values when converting dicts to strings

### DIFF
--- a/src/aya/ReprStream.java
+++ b/src/aya/ReprStream.java
@@ -27,6 +27,7 @@ public class ReprStream {
 	private Stack<Obj> _visited;
 	// In safe mode, do not try to call __repr__ on objects
 	private boolean _safe_mode;
+	private boolean _full_strings; // If long strings will be printed completely or with "abc ... xyz"
 	
 	public ReprStream() {
 		_lines = new ArrayList<ReprStream.Line>();
@@ -35,6 +36,7 @@ public class ReprStream {
 		_visited = new Stack<Obj>();
 		_current_line = new Line(_current_indent);
 		_safe_mode = false;
+		_full_strings = false;
 	}
 
 	
@@ -194,5 +196,14 @@ public class ReprStream {
 	
 	public boolean isSafeMode() {
 		return _safe_mode;
+	}
+
+
+	public void setFullStrings(boolean b) {
+		_full_strings = true;		
+	}
+	
+	public boolean isFullStrings() {
+		return _full_strings;
 	}
 }

--- a/src/aya/obj/dict/Dict.java
+++ b/src/aya/obj/dict/Dict.java
@@ -313,7 +313,10 @@ public class Dict extends Obj {
 	
 	/** Return a string representation of the dict */
 	private String dictStr() {
-		return dictRepr(new ReprStream()).toStringOneline();
+		final boolean fullStr = true;
+		ReprStream stream = new ReprStream();
+		stream.setFullStrings(true);
+		return dictRepr(stream).toString();//.toStringOneline();
 	}
 	
 	/** Return a string representation of the dict 

--- a/src/aya/obj/list/Str.java
+++ b/src/aya/obj/list/Str.java
@@ -429,10 +429,10 @@ public class Str extends ListImpl implements Comparable<Str> {
 
 	@Override
 	public ReprStream repr(ReprStream stream) {
-		if (_str.length() > 100) {
-			stream.print(StringUtils.quote(_str.substring(0, 30) + " ... " + _str.substring(_str.length()-30)));
-		} else {
+		if (stream.isFullStrings() || _str.length() <= 100) {
 			stream.print(StringUtils.quote(_str));
+		} else {
+			stream.print(StringUtils.quote(_str.substring(0, 30) + " ... " + _str.substring(_str.length()-30)));
 		}
 		return stream;
 	}


### PR DESCRIPTION
Previously, when converting a dict to a string, string values in the dict (and string values of nested dicts, etc) would be truncated. This made it impossible to recover the full string unless manually iterating through the dict.

This change makes it so that `P` won't truncate string values when converting dicts to strings