### PR TITLE
fix a regression when parsing Json with decimals

### DIFF
--- a/src/aya/ext/json/JSONUtils.java
+++ b/src/aya/ext/json/JSONUtils.java
@@ -124,8 +124,8 @@ public class JSONUtils {
 			return new List(arr);
 		} else if (object instanceof Integer) {
 			return Num.fromInt((Integer)object);
-		} else if (object instanceof Double) {
-			return new Num((Double)object);
+		} else if (object instanceof Number) {
+			return new Num(((Number)object).doubleValue());
 		} else if (object instanceof String) {
 			String str = (String)object;
 			if (params.parse_symbol && str.startsWith("::")) {

--- a/test/std/test_json.aya
+++ b/test/std/test_json.aya
@@ -1,0 +1,62 @@
+.# see https://www.json.org/json-en.html
+"""{
+    "emptyObj": {},
+    "valuesArray": [
+        {
+            "string": "foo"
+        },
+        {
+            "number0": 0,
+            "number0N": -0,
+            "numberInt": 12,
+            "numberIntN": -12,
+            "numberFr": 0.12,
+            "numberFrN": -0.12,
+            "numberExp": 23.45E3,
+            "numberExpN": 23.45e-3,
+            "numberNExp": -23.45e3,
+            "numberNExpN": -23.45E-3
+        },
+        [1, 2, 3],
+        true,
+        false,
+        null
+    ]
+}""" :(json.loads) :json_obj;
+
+:{
+    :{} :"emptyObj";
+    [
+        :{
+            "foo" :"string";
+        }
+        :{
+            0 :"number0";
+            -0 :"number0N";
+            12 :"numberInt";
+            -12 :"numberIntN";
+            0.12 :"numberFr";
+            -0.12 :"numberFrN";
+            :23.45e3 :"numberExp";
+            :23.45e-3 :"numberExpN";
+            :-23.45e3 :"numberNExp";
+            :-23.45e-3 :"numberNExpN";
+        }
+        [1 2 3]
+        1
+        0
+        ::__json_null
+    ] :"valuesArray";
+} :aya_obj;
+
+
+[
+
+    { json_obj aya_obj }
+
+    {
+        aya_obj :(json.dumps) :(json.loads)
+        aya_obj
+    }
+
+] :# { test.test }

--- a/test/test.aya
+++ b/test/test.aya
@@ -54,6 +54,7 @@
     "enum"
     "csv"
     "io"
+    "json"
     "la"
     "map"
     "matrix"


### PR DESCRIPTION
Introduced by #113
The Json library now (sometimes) creates `BigDecimal`s when parsing decimals.

Example failure:
```
aya> "{test: 1.23}" :(json.loads)
Unsupported type: 1.23


"{test: 1.23}" :(json.loads)
~~~~~~~~~~~~~~~~~~~~~~~~~~~^
Function call traceback:
```