### PR TITLE
Attempt to fix inconsistencies for non-basicSymbolString Symbols

### DIFF
--- a/src/aya/ext/json/JSONUtils.java
+++ b/src/aya/ext/json/JSONUtils.java
@@ -161,7 +161,7 @@ public class JSONUtils {
 				if (vc.hasVisited(e.second())) {
 					throw new ValueError("JSON: Circular reference detected when serializing json object. key: " + e.first());
 				} else {
-					out.put(e.first().unquotedName(), toJSON(e.second(), params, vc));
+					out.put(e.first().name(), toJSON(e.second(), params, vc));
 				}
 			}
 			vc.pop(d);
@@ -188,7 +188,7 @@ public class JSONUtils {
 		} else if (o.isa(Obj.SYMBOL)) {
 			Symbol sym = (Symbol)o;
 			if (params.parse_symbol) {
-				return "::" + sym.name();
+				return sym.str();
 			} else {
 				return sym.name();
 			}

--- a/src/aya/obj/dict/Dict.java
+++ b/src/aya/obj/dict/Dict.java
@@ -17,6 +17,8 @@ import aya.obj.symbol.SymbolConstants;
 import aya.obj.symbol.SymbolTable;
 import aya.util.Casting;
 import aya.util.Pair;
+import aya.util.StringUtils;
+
 /**
  * A set of key-value pairs accessible as a runtime object
  * @author Nick
@@ -378,7 +380,7 @@ public class Dict extends Obj {
 				for (Symbol sym : _vars.keySet()) {
 					if (sym.id() != SymbolConstants.KEYVAR_META.id()) {
 						_vars.get(sym).repr(stream);
-						stream.println(":" + sym.name() + ";");
+						stream.println(":" + StringUtils.quote(sym.name()) + ";");
 					}
 				}
 				stream.decIndent();

--- a/src/aya/obj/symbol/Symbol.java
+++ b/src/aya/obj/symbol/Symbol.java
@@ -17,15 +17,6 @@ public class Symbol extends Obj {
 	}
 	
 	public String name() {
-		String s = SymbolTable.getName(this);
-		if (SymbolTable.isBasicSymbolString(s)) {
-			return s;
-		} else {
-			return StringUtils.quote(s);
-		}
-	}
-	
-	public String unquotedName() {
 		return SymbolTable.getName(this);
 	}
 	
@@ -46,13 +37,13 @@ public class Symbol extends Obj {
 
 	@Override
 	public ReprStream repr(ReprStream stream) {
-		stream.print("::" + name());
+		stream.print(str());
 		return stream;
 	}
 
 	@Override
 	public String str() {
-		return "::" + name();
+		return "::" + StringUtils.quote(name());
 	}
 
 	@Override

--- a/src/aya/parser/Parser.java
+++ b/src/aya/parser/Parser.java
@@ -166,13 +166,13 @@ public class Parser {
 						while (in.hasNext() && SymbolTable.isBasicSymbolChar(in.peek())) {
 							varname += in.next();
 						}
-						tokens.add(new KeyVarToken(varname, in.currentRef()));
+						tokens.add(new KeyVarToken(varname, in.currentRef(), false));
 					}
 
 					else if (in.peek() == '"') {
 						in.next(); // Skip opening "
 						String varname = StringParseUtils.goToEnd(in, '"');
-						tokens.add(new KeyVarToken(varname, in.currentRef()));
+						tokens.add(new KeyVarToken(varname, in.currentRef(), true));
 					}
 
 
@@ -191,7 +191,7 @@ public class Parser {
 						if (in.peek() == '"') {
 							in.next(); // Skip open '
 							String str = StringParseUtils.goToEnd(in, '"');
-							tokens.add(new VarToken(str, in.currentRef()));
+							tokens.add(new VarToken(str, in.currentRef(), true));
 						}
 					}
 
@@ -206,7 +206,7 @@ public class Parser {
 					}
 					
 					else {
-						tokens.add(new KeyVarToken(""+in.next(), in.currentRef()));
+						tokens.add(new KeyVarToken(""+in.next(), in.currentRef(), false));
 					}
 
 				} else {
@@ -325,7 +325,7 @@ public class Parser {
 				while (in.hasNext() && SymbolTable.isBasicSymbolChar(in.peek())) {
 					sb.append(in.next());
 				}
-				tokens.add(new VarToken(sb.toString(), in.currentRef()));
+				tokens.add(new VarToken(sb.toString(), in.currentRef(), false));
 			}
 
 			// Normal Operators
@@ -342,10 +342,12 @@ public class Parser {
 					if (in.peek() == ':') {
 						in.next(); // Move to the next colon
 						String sym = "";
+						final boolean varIsExplicitlyTerminated;
 						if (in.hasNext() && in.peek() == '"') {
 							// Quoted symbol
 							in.next(); // Skip '
 							sym = StringParseUtils.goToEnd(in, '"');
+							varIsExplicitlyTerminated = true;
 						} else {
 
 							// Fist, try to parse as simple variable
@@ -354,7 +356,7 @@ public class Parser {
 							}
 
 							// If empty, check for operator or special character
-							if (sym.equals("")) {
+							if (sym.isEmpty()) {
 								if (in.hasNext()) {
 									
 									// Multi-char operator
@@ -370,9 +372,10 @@ public class Parser {
 									throw new SyntaxError("Expected symbol name", in.currentRef());
 								}
 							}
+							varIsExplicitlyTerminated = false;
 						}
 
-						tokens.add(new SymbolToken(sym, in.currentRef()));
+						tokens.add(new SymbolToken(sym, in.currentRef(), varIsExplicitlyTerminated));
 					}
 					
 					// Named Operator
@@ -412,7 +415,7 @@ public class Parser {
 						tokens.add(new SpecialToken(Token.COLON, ":", in.currentRef()));
 						in.next(); // Skip open "
 						String varname = StringParseUtils.goToEnd(in, '"');
-						tokens.add(new VarToken(varname, in.currentRef()));
+						tokens.add(new VarToken(varname, in.currentRef(), true));
 					}
 
 					// Colon Operator
@@ -446,7 +449,7 @@ public class Parser {
 					tokens.add(tmp);
 				} else if (!Character.isWhitespace(current)){
 					// Single character variable
-					tokens.add(new VarToken(""+current, in.currentRef()));
+					tokens.add(new VarToken(""+current, in.currentRef(), false));
 				}
 			}
 		}

--- a/src/aya/parser/ParserString.java
+++ b/src/aya/parser/ParserString.java
@@ -15,18 +15,27 @@ public class ParserString {
 
 	public ParserString(SourceStringRef source, String substr) {
 		this(source.getSource(), source.getIndex()-substr.length(), substr.length());
-		try {
-			String substr_test = source.getSource().getSource().substring(this.start_ix, this.end_ix);
-			if (!substr_test.equals(substr)) {
-				System.out.println("input<" + substr + ">");
-				System.out.println("source<" + substr_test + ">");
-				throw new AssertionError();
-			}
-		} catch (StringIndexOutOfBoundsException e) {
-			throw e;
+		assertValidSubstring(source, substr);
+	}
+
+	public ParserString(SourceStringRef source, String substr, boolean hasExplicitTerminator) {
+		this(
+				source.getSource(),
+				source.getIndex() - substr.length() + (hasExplicitTerminator ? 0 : 1),
+				substr.length()
+		);
+		assertValidSubstring(source, substr);
+	}
+
+	private void assertValidSubstring(SourceStringRef source, String substr) {
+		String substr_test = source.getSource().getSource().substring(this.start_ix, this.end_ix);
+		if (!substr_test.equals(substr)) {
+			System.out.println("input<" + substr + ">");
+			System.out.println("source<" + substr_test + ">");
+			throw new AssertionError();
 		}
 	}
-	
+
 	private ParserString(SourceString source, int offset, int length) {
 		this.source = source;
 		this.chars = source.getRawString().toCharArray();

--- a/src/aya/parser/StringParseUtils.java
+++ b/src/aya/parser/StringParseUtils.java
@@ -6,26 +6,18 @@ import aya.exceptions.parser.SyntaxError;
 public class StringParseUtils {
 
 	public static String goToEnd(ParserString in, char termination) throws EndOfInputError {
-		boolean ignore_next = false;
 		StringBuilder out = new StringBuilder();
 		while (in.hasNext()) {
 			char c = in.next();
-			
-			if (c == '\\') {
-				if (ignore_next) {
-					// Double backslash, the backslash itself is being escaped
-					ignore_next = false;
-				} else {
-					// Normal backslash, escape the next character
-					ignore_next = true;
-				}
-			} else if (c == termination && !ignore_next) {
+
+			if (c == '\\' && in.hasNext()) {
+				out.append(c);
+				out.append(in.next());
+			} else if (c == termination) {
 				return out.toString();
 			} else {
-				ignore_next = false;
+				out.append(c);
 			}
-			
-			out.append(c);
 		}
 		// End of input
 		return out.toString();

--- a/src/aya/parser/tokens/CDictToken.java
+++ b/src/aya/parser/tokens/CDictToken.java
@@ -1,29 +1,31 @@
 package aya.parser.tokens;
 
+import aya.exceptions.parser.EndOfInputError;
+import aya.exceptions.parser.SyntaxError;
 import aya.instruction.Instruction;
 import aya.instruction.variable.GetCDictInstruction;
 import aya.obj.symbol.Symbol;
 import aya.obj.symbol.SymbolTable;
 import aya.parser.SourceStringRef;
 
-public class CDictToken extends StdToken {
+public class CDictToken extends EscapedToken {
 
-	public CDictToken(String data, SourceStringRef source) {
-		super(data, Token.KEY_VAR, source);
-	}
-	
-	public Symbol getSymbol() {
-		return SymbolTable.getSymbol(data);
-	}
+    public CDictToken(String data, SourceStringRef source) throws SyntaxError, EndOfInputError {
+        super(data, Token.KEY_VAR, source, false);
+    }
 
-	@Override
-	public Instruction getInstruction() {
-		return new GetCDictInstruction(getSourceStringRef(), getSymbol());
-	}
+    public Symbol getSymbol() {
+        return SymbolTable.getSymbol(unescapedData);
+    }
 
-	@Override
-	public String typeString() {
-		return "cdict";
-	}
-		
+    @Override
+    public Instruction getInstruction() {
+        return new GetCDictInstruction(getSourceStringRef(), getSymbol());
+    }
+
+    @Override
+    public String typeString() {
+        return "cdict";
+    }
+
 }

--- a/src/aya/parser/tokens/EscapedToken.java
+++ b/src/aya/parser/tokens/EscapedToken.java
@@ -1,0 +1,24 @@
+package aya.parser.tokens;
+
+import aya.exceptions.parser.EndOfInputError;
+import aya.exceptions.parser.SyntaxError;
+import aya.parser.ParserString;
+import aya.parser.SourceStringRef;
+import aya.parser.StringParseUtils;
+
+/**
+ * A Token whose data needs to be unescaped ({@link StringParseUtils#unescape(ParserString)}) before being used.
+ */
+public abstract class EscapedToken extends StdToken {
+    protected final String unescapedData;
+
+    /**
+     * @param hasExplicitTerminator true to indicate that the data was terminated by a special character (-> source index is off by one)
+     */
+    protected EscapedToken(String data, int type, SourceStringRef source, boolean hasExplicitTerminator)
+            throws SyntaxError, EndOfInputError {
+        super(data, type, source);
+
+        unescapedData = StringParseUtils.unescape(new ParserString(source, data, hasExplicitTerminator));
+    }
+}

--- a/src/aya/parser/tokens/KeyVarToken.java
+++ b/src/aya/parser/tokens/KeyVarToken.java
@@ -1,19 +1,21 @@
 package aya.parser.tokens;
 
+import aya.exceptions.parser.EndOfInputError;
+import aya.exceptions.parser.SyntaxError;
 import aya.instruction.Instruction;
 import aya.instruction.variable.GetKeyVariableInstruction;
 import aya.obj.symbol.Symbol;
 import aya.obj.symbol.SymbolTable;
 import aya.parser.SourceStringRef;
 
-public class KeyVarToken extends StdToken {
+public class KeyVarToken extends EscapedToken {
 
-	public KeyVarToken(String data, SourceStringRef source) {
-		super(data, Token.KEY_VAR, source);
+	public KeyVarToken(String data, SourceStringRef source, boolean hasExplicitTerminator) throws SyntaxError, EndOfInputError {
+		super(data, Token.KEY_VAR, source, hasExplicitTerminator);
 	}
 	
 	public Symbol getSymbol() {
-		return SymbolTable.getSymbol(data);
+		return SymbolTable.getSymbol(unescapedData);
 	}
 
 	@Override

--- a/src/aya/parser/tokens/SymbolToken.java
+++ b/src/aya/parser/tokens/SymbolToken.java
@@ -1,29 +1,32 @@
 package aya.parser.tokens;
 
+import aya.exceptions.parser.EndOfInputError;
+import aya.exceptions.parser.SyntaxError;
 import aya.instruction.DataInstruction;
 import aya.instruction.Instruction;
 import aya.obj.symbol.Symbol;
 import aya.obj.symbol.SymbolTable;
 import aya.parser.SourceStringRef;
 
-public class SymbolToken extends StdToken {
-		
-	public SymbolToken(String data, SourceStringRef source) {
-		super(data, Token.SYMBOL, source);
-	}
-	
-	public Symbol getSymbol() {
-		return SymbolTable.getSymbol(data);
-	}
+public class SymbolToken extends EscapedToken {
 
-	
-	@Override
-	public Instruction getInstruction() {
-		return new DataInstruction(getSymbol());
-	}
+    public SymbolToken(String data, SourceStringRef source, boolean hasExplicitTerminator)
+            throws SyntaxError, EndOfInputError {
+        super(data, Token.SYMBOL, source, hasExplicitTerminator);
+    }
 
-	@Override
-	public String typeString() {
-		return "symbol";
-	}
+    public Symbol getSymbol() {
+        return SymbolTable.getSymbol(unescapedData);
+    }
+
+
+    @Override
+    public Instruction getInstruction() {
+        return new DataInstruction(getSymbol());
+    }
+
+    @Override
+    public String typeString() {
+        return "symbol";
+    }
 }

--- a/src/aya/parser/tokens/VarToken.java
+++ b/src/aya/parser/tokens/VarToken.java
@@ -1,28 +1,31 @@
 package aya.parser.tokens;
 
+import aya.exceptions.parser.EndOfInputError;
+import aya.exceptions.parser.SyntaxError;
 import aya.instruction.Instruction;
 import aya.instruction.variable.GetVariableInstruction;
 import aya.obj.symbol.Symbol;
 import aya.obj.symbol.SymbolTable;
 import aya.parser.SourceStringRef;
 
-public class VarToken extends StdToken {
-		
-	public VarToken(String data, SourceStringRef source) {
-		super(data, Token.VAR, source);
-	}
-	
-	public Symbol getSymbol() {
-		return SymbolTable.getSymbol(data);
-	}
+public class VarToken extends EscapedToken {
 
-	@Override
-	public Instruction getInstruction() {
-		return new GetVariableInstruction(this.getSourceStringRef(), getSymbol());
-	}
+    public VarToken(String data, SourceStringRef source, boolean hasExplicitTerminator)
+            throws SyntaxError, EndOfInputError {
+        super(data, Token.VAR, source, hasExplicitTerminator);
+    }
 
-	@Override
-	public String typeString() {
-		return "var";
-	}
+    public Symbol getSymbol() {
+        return SymbolTable.getSymbol(unescapedData);
+    }
+
+    @Override
+    public Instruction getInstruction() {
+        return new GetVariableInstruction(this.getSourceStringRef(), getSymbol());
+    }
+
+    @Override
+    public String typeString() {
+        return "var";
+    }
 }

--- a/src/aya/util/StringUtils.java
+++ b/src/aya/util/StringUtils.java
@@ -36,13 +36,9 @@ public class StringUtils {
 
 	// Add quotes to a string
 	public static String quote(String s) {
-		s = s.replaceAll("\\\"", "\\\\\"");
+		s = s.replace("\\", "\\\\");
+		s = s.replace("\"", "\\\"");
 		return '"' + s + '"';
-	}
-
-	public static String singleQuote(String s) {
-		s = s.replaceAll("\\\'", "\\\\\'");
-		return "'" + s + "'";
 	}
 
 	/** Test if a string contains all lowercase alphabetical letters */

--- a/test/repr.aya
+++ b/test/repr.aya
@@ -1,0 +1,88 @@
+.# This test covers conversion of Objects from and to Strings
+
+[
+    "a"
+    "A"
+    "3"
+    ""
+    "\""
+    "\\"
+    "\\\""
+    "2 1 -"
+]:tricky_keys;
+
+[
+    ::a
+    ::"A"
+    ::"3"
+    ::""
+    ::"\""
+    ::"\\"
+    ::"2 1 -"
+]:tricky_symbols;
+
+.# Dictionary with various "tricky" keys and values
+:{
+    [1 1.2 -3] :list;
+    :{1:a;2:b;} :dict;
+    "foo" :str;
+    tricky_symbols :symbols;
+}:tricky_dict;
+
+.# store tricky keys in the dictionary
+tricky_keys E .R # {i,
+    i tricky_dict.:[ tricky_keys.[i] ];
+};
+
+.# json.dumps writes symbols by their name instead. Remove 'symbols' from the copy.
+tricky_dict $\; :tricky_dict_for_json;
+tricky_dict_for_json "symbols" .- ;
+
+[
+    .# Expect P to cast Objects to the Aya-Code of themselves as a String
+    {
+        "  test: dict P~":P
+        tricky_dict :& P~ \
+    }
+
+    .# Block (mapped with {P} to compare string representations, as comparing the blocks directly doesn't work)
+    {
+        "  test: block P~":P
+        [
+            {x, x R .[i] .[1] .:[i] .:[1] :a}
+            :& P~
+        ] # {P}~ \
+    }
+
+    .# the JSON instructions also rely on symbol names
+    {
+        "  test: dict :(json.dumps) :(json.loads)":P
+        tricky_dict_for_json :& :(json.dumps) :(json.loads) \
+    }
+
+
+    .# {:S :C} (string to symbol and back to string) should give the original string
+    {
+        "  test: str :S :C":P
+        tricky_keys :& # { :S :C } \
+    }
+
+    .# {:C :S} (symbol to string and back to symbol) should give the original symbol
+    {
+        "  test: symbol :C :S":P
+        tricky_symbols :& # { :C :S } \
+    }
+
+    .# { :K :C } (keys of dict as symbols, to string) should give a valid key for the dictionary
+    {
+        "  test: dict :K # {:C}":P
+
+        .# setup: create a dictionary containing each key assigned to itself
+        :{} :tricky_key_dict;
+        tricky_keys # {k, k tricky_key_dict.:[k];};
+
+        .# assert (list of keys as str) = (dict[list of keys as str])
+        tricky_key_dict :K # {:C} :& # {k, tricky_key_dict.[k]} \
+    }
+
+] :# { test.test }

--- a/test/test.aya
+++ b/test/test.aya
@@ -33,6 +33,7 @@
 "test/dot_ops" load_test
 "test/colon_ops" load_test
 "test/range" load_test
+"test/repr" load_test
 "test/broadcast" load_test
 "test/unicode" load_test
 "test/misc" load_test


### PR DESCRIPTION
(!) Beware: I cannot fully gauge the potential side-effects of this change.
- please verify my assumptions (below)
- if you think I'm missing important test cases, this would be a good opportunity to add them

---

#### Motivation:

Working with Dictionaries has been bugging me for a while. In particular `:K` and `:C` when using certain Key names.

Expected: `[ 1 ]`
```aya
aya> :{1:"A"} :dict :K # {key, dict.[key :C] }
Dict does not contain key '"\"A\""':
:{
  1:"A";
}
```

While testing, I have noticed this bug:

Expected: `::"\""`
```aya
aya> ::"\""
::"\\""
```

---

#### Assumptions:

- `P~` should always return the original object
  - (*) does not hold for str and char. (I'd argue it should, e.g. `"a"P~` should return `"a"`. Open to discussion)
  - this already works for lists, dicts, blocks, numbers, basic symbols (`/[a-z_]+/`)
  - *it now also works for non-basic symbols (including in lists and dicts)*
- `:S :C` converting Strings to Symbols and back should always return the original String
- `:C :S` should also always return the original Symbol
- The String returned by `:C` for Symbols in dicts (`:K`) should index the same entry.

---

### Changes

- Symbol.name() is always unquoted. Symbol.unquotedName() has been removed.
  - (!) This method is used in a lot of places. (mostly for basic names, so no change there)
- Symbol.str() and Symbol.repr() are always quoted.
- new 'EscapedToken' class that 'CDictToken', 'KeyVarToken', 'SymbolToken' and 'VarToken' extend from to obtain the unquoted data string.
- StringUtils.quote() always escapes `\` and `"`

#### Some side-by-sides

Setup:
```aya
[
    "a"
    "A"
    "3"
    ""
    "\""
    "\\"
    "\\\""
    "2 1 -"
]:tricky_keys;

[
    ::a
    ::"A"
    ::"3"
    ::""
    ::"\""
    ::"\\"
    ::"2 1 -"
]:tricky_symbols;

.# Dictionary with various "tricky" keys and values
:{
    [1 1.2 -3] :list;
    {x, xR} :block;
    :{1:a;2:b;} :dict;
    "foo" :str;
    tricky_symbols :symbols;
}:tricky_dict;

.# store tricky keys in the dictionary
tricky_keys E .R # {i,
    i tricky_dict.:[ tricky_keys.[i] ];
};
```

<table>
<tr>
<th>
before (current master branch)
</th>
<th>
after
</th>
</tr>
<tr>
<td>
aya>&nbsp;["\\"]P~<br/>
No&nbsp;closing&nbsp;delimiter&nbsp;found<br/>
[&nbsp;"\"&nbsp;]<br/>
^
</td>
<td>
aya>&nbsp;["\\"]P~<br/>
[&nbsp;"\\"&nbsp;]
</td>
</tr>
<tr>
<td>
aya>&nbsp;"A"&nbsp;:S&nbsp;:C<br/>
"\"A\""
</td>
<td>
aya>&nbsp;"A"&nbsp;:S&nbsp;:C<br/>
"A"
</td>
</tr>
<tr>
<td>
aya>&nbsp;::"\""<br/>
::"\\""
</td>
<td>
aya>&nbsp;::"\""<br/>
::"\""
</td>
</tr>
<tr>
<td>
aya>&nbsp;tricky_keys<br/>
[&nbsp;"a"&nbsp;"A"&nbsp;"3"&nbsp;""&nbsp;"\""&nbsp;"\"&nbsp;"\\""&nbsp;"2&nbsp;1&nbsp;-"&nbsp;]
</td>
<td>
aya>&nbsp;tricky_keys<br/>
[&nbsp;"a"&nbsp;"A"&nbsp;"3"&nbsp;""&nbsp;"\""&nbsp;"\\"&nbsp;"\\\""&nbsp;"2&nbsp;1&nbsp;-"&nbsp;]
</td>
</tr>
<tr>
<td>
aya>&nbsp;tricky_symbols<br/>
[&nbsp;::a&nbsp;::"A"&nbsp;::"3"&nbsp;::""&nbsp;::"\\""&nbsp;::"\\"&nbsp;::"2&nbsp;1&nbsp;-"&nbsp;]
</td>
<td>
aya>&nbsp;tricky_symbols<br/>
[&nbsp;::"a"&nbsp;::"A"&nbsp;::"3"&nbsp;::""&nbsp;::"\""&nbsp;::"\\"&nbsp;::"2&nbsp;1&nbsp;-"&nbsp;]
</td>
</tr>
<tr>
<td>
aya>&nbsp;tricky_dict<br/>
:{<br/>
&nbsp;&nbsp;"foo":str;<br/>
&nbsp;&nbsp;{x,x&nbsp;R}:block;<br/>
&nbsp;&nbsp;[&nbsp;1&nbsp;1.2&nbsp;-3&nbsp;]:list;<br/>
&nbsp;&nbsp;[&nbsp;::a&nbsp;::"A"&nbsp;::"3"&nbsp;::""&nbsp;::"\\""&nbsp;::"\\"&nbsp;::"2&nbsp;1&nbsp;-"&nbsp;]:symbols;<br/>
&nbsp;&nbsp;:{<br/>
&nbsp;&nbsp;&nbsp;&nbsp;1:a;<br/>
&nbsp;&nbsp;&nbsp;&nbsp;2:b;<br/>
&nbsp;&nbsp;}:dict;<br/>
&nbsp;&nbsp;0:a;<br/>
&nbsp;&nbsp;1:"A";<br/>
&nbsp;&nbsp;2:"3";<br/>
&nbsp;&nbsp;3:"";<br/>
&nbsp;&nbsp;4:"\"";<br/>
&nbsp;&nbsp;5:"\";<br/>
&nbsp;&nbsp;6:"\\"";<br/>
&nbsp;&nbsp;7:"2&nbsp;1&nbsp;-";<br/>
}
</td>
<td>
aya>&nbsp;tricky_dict<br/>
:{<br/>
&nbsp;&nbsp;"foo":"str";<br/>
&nbsp;&nbsp;{x,x&nbsp;R}:"block";<br/>
&nbsp;&nbsp;[&nbsp;1&nbsp;1.2&nbsp;-3&nbsp;]:"list";<br/>
&nbsp;&nbsp;[&nbsp;::"a"&nbsp;::"A"&nbsp;::"3"&nbsp;::""&nbsp;::"\""&nbsp;::"\\"&nbsp;::"2&nbsp;1&nbsp;-"&nbsp;]:"symbols";<br/>
&nbsp;&nbsp;:{<br/>
&nbsp;&nbsp;&nbsp;&nbsp;1:"a";<br/>
&nbsp;&nbsp;&nbsp;&nbsp;2:"b";<br/>
&nbsp;&nbsp;}:"dict";<br/>
&nbsp;&nbsp;0:"a";<br/>
&nbsp;&nbsp;1:"A";<br/>
&nbsp;&nbsp;2:"3";<br/>
&nbsp;&nbsp;3:"";<br/>
&nbsp;&nbsp;4:"\"";<br/>
&nbsp;&nbsp;5:"\\";<br/>
&nbsp;&nbsp;6:"\\\"";<br/>
&nbsp;&nbsp;7:"2&nbsp;1&nbsp;-";<br/>
}
</td>
</tr>
</table>