### PR TITLE
Add support for "subtables" in asciitable

### DIFF
--- a/examples/asciitable.aya
+++ b/examples/asciitable.aya
@@ -1,7 +1,7 @@
-import asciitable
+require asciitable {asciitable}
 
 .{ Simple Example .}
-:{} asciitable.asciitable! :table;
+:{} asciitable! :table;
 ["my" "header"] table.add_header
 3.R table.add_row .# you don't need to pay attention to your column-count. the table is extended on demand
 table :P
@@ -14,7 +14,7 @@ table :P
     '- :border_bottom
     "||" :border_left
     "||" :border_right
-} asciitable.asciitable! :table;
+} asciitable! :table;
 1 1 table.set_col_align
 
 ["foo" "bar"] table.add_header
@@ -24,6 +24,24 @@ table.add_header_sep
 table.add_row_sep
 ["other data"] table.add_header
 [3R 10R] table.add_rows
+
+table :P
+"":P
+
+
+.{ Example with subtable .}
+:{1:row_align;} asciitable! :table;
+["task" "count" "time"] table.add_header
+["" "" ["total" "avg."]] table.add_header
+table.add_header_sep
+
+0 -1 table.set_col_align
+2 :{"":col_sep;} table.set_col_subtable .# make column[2] a subtable column, options are inherited from this table and merged with the options argument.
+
+["foo" 120 ["75 s" "$(75 120 / 2.fixed) s"]] table.add_row
+["bar" 99 ["115 s" "$(115 99 / 2.fixed) s"]] table.add_row
+["abnormal1" 5 "line1\nline2"] table.add_row .# cells in subtables that are not ::list are left untouched
+["abnormal2" "line1\nline2" ["4 s" "$(4 2 / 2.fixed) s"]] table.add_row .# subtables in rows with multi-line cells work as well
 
 table :P
 "":P

--- a/std/asciitable.aya
+++ b/std/asciitable.aya
@@ -80,6 +80,8 @@ def asciitable::__init__ {options::dict self,
 
     :{} self.:column_align; .# stores columns that should be aligned differently (key=col_idx, value=mode)
 
+    :{} self.:subtable_by_column; .# allow user to define columns that contain multiple values
+
     [] self.:rows; .# start empty
 }
 
@@ -142,9 +144,53 @@ def asciitable::set_col_align {col_idx align_mode self,
     align_mode self.column_align.:[col_idx P] ;
 }
 
-def asciitable::__repr__ {self : col_sep row_data col_widths formatters border_left_width make_transposable^ pad_str^,
+.# make a column a subtable.
+def asciitable::set_col_subtable {col_idx options::dict self : asciitable^,
+    self.options $\; options .+ asciitable! self.subtable_by_column.:[col_idx P] ;
+}
 
-    self.rows {row, "hr" row.type H } I # {.data} :row_data;
+.# modify rows such that each ::list in a subtable-column is replaced with the rendered ::str
+def asciitable::_render_subtables {rows self : subtable_cells_by_column,
+    self.subtable_by_column :K E 0 > {
+        self.subtable_by_column :V # {subtable, subtable.clear} ;
+    
+        .# write ::list cells into their subtables
+        rows # {row,
+            {
+                (row.type 'h =) {
+                    row.data E .R {col_idx, self.subtable_by_column col_idx P H} I {col_idx, row.data.[col_idx] :T ::list =} I # {col_idx,
+                        row.data.[col_idx] self.subtable_by_column.[col_idx P] .add_header
+                    };
+                }
+                (row.type 'r =) {
+                    row.data E .R {col_idx, self.subtable_by_column col_idx P H} I {col_idx, row.data.[col_idx] :T ::list =} I # {col_idx,
+                        row.data.[col_idx] self.subtable_by_column.[col_idx P] .add_row
+                    };
+                }
+            }:?
+        };
+        
+        :{} :subtable_cells_by_column;
+        self.subtable_by_column :K # {col_sym,
+            0 self.subtable_by_column.[col_sym] ._get_repr_cells; subtable_cells_by_column.:[col_sym] ;
+        };
+        
+        .# write subtable cells back into the ::list cells of this table
+        rows {row, "hr" row.type H} I # {row,
+            row.data E .R {col_idx, subtable_cells_by_column col_idx P H} I {col_idx, row.data.[col_idx] :T ::list =} I # {col_idx,
+                subtable_cells_by_column.[col_idx P] V\; row.data.:[col_idx] ;
+            };
+        };
+    }?
+}
+
+.# pad_left_right ::bool if true: apply left padding on leftmost cell and right padding on rightmost cell
+.# returns (cell_rows::list[::str] col_widths::list[::num])
+def asciitable::_get_repr_cells {pad_left_right self : rows col_sep row_data col_data col_widths formatters border_left_width make_transposable^ pad_str^,
+    .# take a deep-copy to avoid modifying the original data
+    self.rows $ :rows;;
+    rows self._render_subtables
+    rows {row, "hr" row.type H } I # {.data} :row_data;
     row_data "" make_transposable
 
     .# figure out how wide each column is
@@ -166,7 +212,7 @@ def asciitable::__repr__ {self : col_sep row_data col_widths formatters border_l
                 self.options.header_align
                 self.options.pad_char
                 pad_str
-            } col_sep % self.options.pad_char \.V self.options.pad_char \.B }~
+            } col_sep % pad_left_right {self.options.pad_char \.V self.options.pad_char \.B}? }~
         }:"h"
         {row,
             col_widths 2+ # {width, self.options.header_sep width L} self.options.col_sep %
@@ -180,7 +226,7 @@ def asciitable::__repr__ {self : col_sep row_data col_widths formatters border_l
                 self.column_align col_idx P H { self.column_align.[col_idx P] }{ self.options.row_align }.?
                 self.options.pad_char
                 pad_str
-            } col_sep % self.options.pad_char \.V self.options.pad_char \.B }~
+            } col_sep % pad_left_right {self.options.pad_char \.V self.options.pad_char \.B}? }~
         }:"r"
         {row,
             col_widths 2+ # {width, self.options.row_sep width L} self.options.col_sep %
@@ -188,10 +234,15 @@ def asciitable::__repr__ {self : col_sep row_data col_widths formatters border_l
     }:formatters;
 
     .# convert row objects to row ascii lines
-    self.rows # {row,
+    rows # {row,
         row formatters.[row.type P]~
     }
-    .# list of ::str on stack
+    col_widths
+}
+
+def asciitable::__repr__ {self : col_widths,
+    1 self._get_repr_cells :col_widths;
+    .# ::list[::str] stack
 
     .# apply borders if enabled
     self.options.border_left 0 = ! {


### PR DESCRIPTION
So sorry to open a PR the instant you merged the original one, but I've *just* finished adding a real-world use case of mine.

## Problem description

I have a table with multiple columns that belong to a logical group.
I am unhappy with this:
```
|      Job       | count | PENDING -> STARTED |   avg.   | STARTED -> FINISHED |  load  |    avg.    | 10 minute peak |   total  |  load |
|================|=======|====================|==========|=====================|========|============|================|==========|=======|
| timeline       | 11285 |           1347.5 s | 119.4 ms |           29255.1 s | 33.8 % | 2592.39 ms |            269 | 1183.0 s | 197 % |
| statisticsCode |  7789 |           1063.3 s | 136.5 ms |            1087.7 s |  1.2 % |  139.65 ms |            251 |   55.2 s |   9 % |
| hl7            |   329 |             39.4 s | 119.7 ms |             129.2 s |  0.1 % |  392.70 ms |             18 |    6.8 s |   1 % |
| generate flags |    11 |              1.3 s | 120.5 ms |               1.0 s |  0.0 % |   90.90 ms |              3 |    0.4 s |   0 % |
```

I would prefer this:
```
|      Job       | count | PENDING -> STARTED |      STARTED -> FINISHED      |     10 minute peak     |
|                |       |  total      avg.   |   total     load      avg.    | count   total    load  |
|================|=======|====================|===============================|========================|
| timeline       | 11285 | 1347.5 s  119.4 ms | 29255.1 s  33.8 %  2592.39 ms |   269  1183.0 s  197 % |
| statisticsCode |  7789 | 1063.3 s  136.5 ms |  1087.7 s   1.2 %   139.65 ms |   251    55.2 s    9 % |
| hl7            |   329 |   39.4 s  119.7 ms |   129.2 s   0.1 %   392.70 ms |    18     6.8 s    1 % |
| generate flags |    11 |    1.3 s  120.5 ms |     1.0 s   0.0 %    90.90 ms |     3     0.4 s    0 % |
```

---

## Changes

I've added a function `set_col_subtable`.
Any cells in that column of type `list` are then formatted by the subtable.

Expected example table:
```
|   task    | count |     time      |
|           |       | total   avg.  |
|===========|=======|===============|
| foo       |   120 |  75 s   .62 s |
| bar       |    99 | 115 s  1.16 s |
| abnormal1 |     5 |         line1 |
|           |       |         line2 |
| abnormal2 | line1 |   4 s     2 s |
|           | line2 |               |
```

---

`__repr__` now deep-copies the data.
Previously the 'make_transposable' function made changes that could be seen by the user.

Before:
```
aya> :{} asciitable! :table;
aya> 2R :la table.add_row
aya> 3R :lb table.add_row
aya> la lb
[ 1 2 "" ] [ 1 2 3 ]
```

After:
```
aya> :{} asciitable! :table;
aya> 2R :la table.add_row
aya> 3R :lb table.add_row
aya> la lb
[ 1 2 ] [ 1 2 3 ]
```