### PR TITLE
Fix crash when attempting to load an empty file

### DIFF
--- a/src/aya/instruction/op/ColonOps.java
+++ b/src/aya/instruction/op/ColonOps.java
@@ -727,7 +727,7 @@ class OP_Colon_F extends Operator {
 			}
 			
 			// Is there a shebang? If yes, drop the first line
-			if (content.charAt(0) == '#' && content.charAt(1) == '!') {
+			if (content.length() > 0 && content.charAt(0) == '#' && content.charAt(1) == '!') {
 				int line_end = content.indexOf('\n');
 				content = content.substring(line_end);
 			}


### PR DESCRIPTION
This would cause a crash due to trying to check if there was a shebang at the beginning of the file file:

```
aya> "" "empty_file.aya" 0 .G
aya> "empty_file.aya" :F
```