### PR TITLE
Refactor command line arguments; add additional options

### DIFF
--- a/src/aya/InteractiveAya.java
+++ b/src/aya/InteractiveAya.java
@@ -152,7 +152,7 @@ public class InteractiveAya {
 		_showPromptText = false;
 	}
 	
-	public static void printResult(AyaStdIO io, ExecutionResult result) {
+	public static void printResult(AyaStdIO io, ExecutionResult result, boolean raw) {
 		if (result != null) {
 			switch (result.getType()) {
 			case ExecutionResult.TYPE_SUCCESS:
@@ -162,7 +162,11 @@ public class InteractiveAya {
 					ArrayList<Obj> data = res.getData();
 					if (data.size() > 0) {
 						for (int i = 0; i < data.size(); i++) {
-							io.out().print(data.get(i));
+							if (raw) {
+								io.out().print(data.get(i).str());
+							} else {
+								io.out().print(data.get(i));
+							}
 							if (i < data.size() - 1) io.out().print(' ');
 						}
 						io.out().println();
@@ -193,6 +197,7 @@ public class InteractiveAya {
 		PrintStream out = _io().out();
 		PrintStream err = _io().err();		
 		Scanner scanner = ((ScannerInputWrapper)(_io().inputWrapper())).getScanner();
+		boolean rawOutput = !_interactive;
 		
  		_aya.start();
 		
@@ -201,7 +206,7 @@ public class InteractiveAya {
 		while (unfinished_requests) {
 			try {
 				ExecutionResult res = _aya.waitForResponse();
-				printResult(_io(), res);
+				printResult(_io(), res, rawOutput);
 				
 				// done?
 				if (res.id() >= _request_id_counter) unfinished_requests = false;
@@ -244,7 +249,7 @@ public class InteractiveAya {
 						while (_aya.hasPendingTasks()) {
 							ExecutionResult result = _aya.waitForResponse();
 							if (result.id() == request.id()) {
-								printResult(_io(), result);
+								printResult(_io(), result, rawOutput);
 							}
 						}
 					} catch (InterruptedException e) {

--- a/src/ui/AyaIDE.java
+++ b/src/ui/AyaIDE.java
@@ -12,6 +12,8 @@ import java.beans.PropertyChangeListener;
 import java.io.File;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 import javax.swing.Action;
 import javax.swing.JFileChooser;
@@ -22,6 +24,7 @@ import javax.swing.JMenuItem;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 
+import aya.AyaPrefs;
 import aya.AyaStdIO;
 import aya.AyaThread;
 import aya.ExecutionRequest;
@@ -48,6 +51,8 @@ public class AyaIDE extends JFrame
 			+ "Source: github.com/nick-paul/aya-lang\n"
 			+ "Wiki: github.com/nick-paul/aya-lang/wiki";
 
+	private final static int RESCODE_OK  = 0;
+	private final static int RESCODE_ERR = 1;
 
 
 	private AyaThread _aya;
@@ -349,27 +354,185 @@ public class AyaIDE extends JFrame
 	public InputStream getInputStream() {
 		return _interpreter.getIn();
 	}
+	
+	private static class CLIOptions {
+		// What to do after processing CLI args
+		public static final int MODE_EXIT = 0; // Exit after processing CLI args
+		public static final int MODE_REPL = 1; // Enter the command line REPL
+		public static final int MODE_GUI = 2; // Open the GUI
+		
+		public static final int SPECIAL_MODE_NONE = 0; // Print help text and exit
+		public static final int SPECIAL_MODE_PRINT_HELP = 1; // Print help text and exit
+		public static final int SPECIAL_MODE_PRINT_VERSION = 2; // Print help text and exit
+
+
+		
+		// Options
+		
+		// Runtime working directory
+		public String workingDir = null;
+		// If true, import the golf standard library
+		public boolean autoImportGolf = false;
+		// If not null, run this expression on startup
+		public String expressionToRun = null;
+		// Interactive mode
+		// By default, if no args are provided, we open the GUI
+		public int mode = MODE_EXIT;
+		// Special args that don't require the aya runtime
+		public int specialMode = SPECIAL_MODE_NONE;
+		// File to run
+		public String fileToRun = null;
+		// If not null, run this package
+		public String packageToRun = null;
+		
+		public CLIOptions() { }
+		
+		public static CLIOptions parse(String[] args) throws RuntimeException {
+			CLIOptions options = new CLIOptions();
+			
+			// Special case for double clicking the jar icon: Just launch the GUI
+			if (args.length == 0) {
+				options.mode = MODE_GUI;
+				return options;
+			}
+
+			// First arg is always the working directory
+			if (args.length >= 1) {
+				options.workingDir = args[0];
+			}
+			
+			// 2nd arg is flags or a special case like --help or --version
+			// Only compact format for args is supported
+			// The first arg must start with a "-" and may include any of the following characters
+			// i: Run in CLI mode
+			// e: Run an expression give by arg[2], then exit
+			// g: Import golf standard library before running code
+			// p: Run pkg.run on arg[2]
+			if (args.length >= 2) {
+				String arg = args[1];
+				
+				// Special case for --help and --version
+				if (arg.equals("--help")) {
+					options.specialMode = SPECIAL_MODE_PRINT_HELP;
+				} else if (arg.equals("--version")) {
+					options.specialMode = SPECIAL_MODE_PRINT_VERSION;
+				} else {
+					// aya <file>.aya
+					if (arg.endsWith(".aya")) {
+						options.fileToRun = arg;
+					}
+					// aya -<options>
+					else if (arg.startsWith("-")) {
+						
+						// Auto import golf
+						if (arg.contains("g")) {
+							options.autoImportGolf = true;
+							//iaya.compileAndQueueInput("<system>", "import golf");
+						}
+						
+						// Enter REPL after running initial requests
+						if (arg.contains("i")) {
+							options.mode = MODE_REPL;							
+						}
+						// Enter REPL after running initial requests
+						if (arg.contains("x")) {
+							options.mode = MODE_GUI;							
+						}
+						
+						// Options that require a 3rd argument
+						if (arg.contains("p")) {
+							if (args.length >= 3) {
+								options.packageToRun = args[2];
+							} else {
+								throw new RuntimeException("Error: Please provide a package name");
+							}
+						} else if (arg.contains("e")) {
+							if (args.length >= 3) {
+								options.expressionToRun = args[2];
+							} else {
+								throw new RuntimeException("Error: No expression provided");
+							}
+						} else {
+							// fallback, 3rd arg may be a filename
+							if (args.length >= 3 && args[2].contains(".aya")) {
+								options.fileToRun = args[2];
+							}
+						}
+						
+					} else {
+						throw new RuntimeException("Error: Invalid argument " + options);
+					}
+				}
+			} else {
+				options.mode = MODE_REPL;
+			}
+				
+			return options;
+		}
+	}
+	
 
 	public static void main(String[] args) {
 		// Set to System.in/out/err. If using the GUI, these will be changed to IDE GUI later
 		StaticData.IO = new AyaStdIO(System.out, System.err, System.in, new ScannerInputWrapper(System.in));
 		StaticData.HTTP_DOWNLOADER = new HTTPDownloader();
 		StaticData.FILESYSTEM = new FilesystemIO();
+		AyaPrefs.setArgs(args);
+		
+		CLIOptions options = new CLIOptions();
+		try {
+			options = CLIOptions.parse(args);
+		} catch (RuntimeException e) {
+			StaticData.IO.out().print(e.getMessage());
+			System.exit(RESCODE_ERR);
+		}
 
-		InteractiveAya iaya = InteractiveAya.createInteractiveSession(args);
-
-		boolean readstdin = StaticData.IO.isInputAvaiable();
-
-		if (args.length > 1 || readstdin) {
-			// If reading from STDIN (piped input), don't use interactive mode
-			if (readstdin) InteractiveAya.setInteractive(false);
-		} else {
-			// Use the GUI
-
+		// Special cases
+		
+		if (options.specialMode == CLIOptions.SPECIAL_MODE_PRINT_HELP) {
+			StaticData.IO.out().print(InteractiveAya.HELP_TEXT);
+			System.exit(RESCODE_OK);
+		} else if (options.specialMode == CLIOptions.SPECIAL_MODE_PRINT_VERSION) {
+			StaticData.IO.out().print(StaticData.VERSION_NAME);
+			System.exit(RESCODE_OK);						
+		}
+		
+		InteractiveAya iaya = InteractiveAya.createInteractiveSession(options.workingDir);
+		
+		if (options.autoImportGolf) {
+			iaya.compileAndQueueSystemInput("<system>", "require golf *");
+		}
+		
+		if (options.expressionToRun != null) {
+			iaya.compileAndQueueSystemInput("-e", options.expressionToRun);
+		}
+		
+		if (options.packageToRun != null) {
+			iaya.compileAndQueueSystemInput("-p", "import pkg");
+			iaya.compileAndQueueSystemInput("-p", "\"\"\"" + options.packageToRun + "\"\"\" pkg.run");
+		}
+		
+		if (options.fileToRun != null) {
+			Path path = Paths.get(options.fileToRun);
+			if (!path.isAbsolute()) {
+				path = Paths.get(AyaPrefs.getAyaDir(), options.fileToRun);
+			}
+			String pathString = path.toString().replace("\\", "\\\\");
+			
+			iaya.compileAndQueueSystemInput("<ayarc loader>", "\"\"\"" + pathString + "\"\"\" :F");
+		}
+		
+		if (options.mode == CLIOptions.MODE_EXIT) {
+			iaya.setInteractive(false); // Exit once complete
+		} else if (options.mode == CLIOptions.MODE_REPL) {
+			iaya.setInteractive(true);
+		} else if (options.mode == CLIOptions.MODE_GUI) {
+			iaya.setInteractive(true);
+			
 			//Load and initialize the ide
 			AyaIDE ide = new AyaIDE(iaya.getMainThread());
 
-			// Aya Prefs
+			// Redirect IO to GUI
 			StaticData.IO.setOut(ide.getOutputStream());
 			StaticData.IO.setErr(ide.getOutputStream());
 			StaticData.IO.setIn(ide.getInputStream(), new ScannerInputWrapper(ide.getInputStream()));
@@ -380,8 +543,11 @@ public class AyaIDE extends JFrame
 
 			//Grab focus
 			ide._interpreter.getInputLine().grabFocus();
-
 		}
+
+
+		//if (readstdin) InteractiveAya.setInteractive(false);
+		
 
 		int resultCode = iaya.loop();
 		System.exit(resultCode);

--- a/src/ui/EditorWindow.java
+++ b/src/ui/EditorWindow.java
@@ -222,7 +222,7 @@ public class EditorWindow extends JPanel {
 			// This call could be getting a task from the REPL and is not guaranteed to be the one we just sent
 			try {
 				ExecutionResult res = _aya.waitForResponse();
-				InteractiveAya.printResult(StaticData.IO, res);
+				InteractiveAya.printResult(StaticData.IO, res, false);
 			} catch (ThreadError e) {
 				StaticData.IO.err().print(e.getMessage());
 			} catch (InterruptedException e) {

--- a/std/golf.aya
+++ b/std/golf.aya
@@ -8,7 +8,7 @@
 .# Import standard library
 :(sys.ad) "/std"+ :(sys.readdir) :# { ".aya".^ S W } :# {name, 
     name "golf" =! {
-        "importing $name...":P 
+        .# "importing $name...":P 
         name __aya__.importlib.import
     } ?
 };


### PR DESCRIPTION
This PR adds several CLI arguments

A summary of the new options is available using the new `--help` argument

```
$ aya --help
aya v0.6.0-SNAPSHOT
  aya
    Running aya with no args will open the GUI IDE at the default working directory
    Note: Default setting is GUI so that double clicking the jar from a file explorer opens the IDE
    Use `aya <workingDir> -x` to open the GUI at a specified directory
  aya <workingDir>
    Open a command line REPL
  aya <workingDir> <filename>
    Run the file and exit
  aya <workingDir> -<flags> <option1>
    g: Import std/golf and bring all variables into scope
    e: Run the expression given by <option1>
    p: Run the package name given by <opion1>
    i: Enter the REPL after finishing CLI tasks
    x: Launch the GUI
    If <option1> is an aya source file, run it
  aya --help
    Print this message.
  aya --version
    Print version information
```

## Examples

### Run an expression

```
$ aya -e "1 2 +"
3
```

### Bring golf into scope, then run an expression

```
aya -ge '"AF"R$`.<:*n%'
ABCDEF
BBCDEF
CCCDEF
DDDDEF
EEEEEF
FFFFFF
```

### Run a file, then enter interactive mode

```
$ cat test.aya
"Hello world!" :P
"Aya" :name;
$ aya -i test.aya
Hello world!
aya> name
"Aya"
aya> 
```

### Run a package entrypoint

See *sample* package entrypoint here: https://github.com/nick-paul/sample.aya/blob/main/src/angle_conversion_utility.aya
Same as running `import pkg "sample" pkg.run`

```
$ aya -p sample
== Angle Conversion Utility ==
Enter an angle in degrees: 180
Radians: 3.14159265
Conversion complete.
```

### Combine any option with the GUI flag (`-x`)

```
aya -gex '"AF"R$`.<:*n%'
```

![image](https://github.com/user-attachments/assets/bf5b2fc5-62e8-472e-81ed-709e4877380a)

```
$ aya -px sample
```

![image](https://github.com/user-attachments/assets/fcde8520-f74e-4ec9-b7d8-9d587a524117)
