### PR TITLE
Add `-c` flag to only check a file for syntax errors but not run it

### DIFF
--- a/src/aya/StandaloneAya.java
+++ b/src/aya/StandaloneAya.java
@@ -35,14 +35,20 @@ public class StandaloneAya {
     
     // An extremely basic linter that catches syntax errors only
     // Currently the parser will stop after the first error, may need to update later
-    public static ArrayList<ParserException> lint(String input) {
+    public static ArrayList<ParserException> lint(String input, String filename) {
     	ArrayList<ParserException> errors = new ArrayList<ParserException>();
         try {
-        	Parser.compile(new SourceString(input, "<main>"));
+        	Parser.compile(new SourceString(input, filename));
         } catch (ParserException err) {
         	errors.add(err);
         }
         return errors;
+    }
+    
+    // An extremely basic linter that catches syntax errors only
+    // Currently the parser will stop after the first error, may need to update later
+    public static ArrayList<ParserException> lint(String input) {
+    	return lint(input, "<main>");
     }
     
     public static void runIsolated(String input, AyaStdIO io) {

--- a/src/aya/exceptions/parser/ParserException.java
+++ b/src/aya/exceptions/parser/ParserException.java
@@ -9,13 +9,22 @@ import aya.parser.SourceStringRef;
 @SuppressWarnings("serial")
 public class ParserException extends AyaException {
 	
+	// Used by the linter to get just the error message without the extra context string
+	String errorMessageNoContext;
+	
 	protected ParserException(Symbol type, String msg, SourceStringRef source) {
 		super(type, msg + "\n" + source.getContextStr());
 		this.setSource(source);
+		this.errorMessageNoContext = msg;
 	}
 
 	public ParserException(String msg, SourceStringRef source) {
 		super(SymbolConstants.PARSER_ERR, msg + "\n" + source.getContextStr());
+		this.errorMessageNoContext = msg;
+	}
+	
+	public String getErrorMessageNoContext() {
+		return this.errorMessageNoContext;
 	}
 
 	@Override

--- a/src/aya/parser/SourceString.java
+++ b/src/aya/parser/SourceString.java
@@ -100,6 +100,13 @@ public class SourceString {
 		return lineCount;
 	}
 	
+	
+	public int getLineCharNumber(int charIndex) {
+		IndexedSourceLine isl = this.getIndexedLine(charIndex);
+		return isl.index;
+	}
+
+	
 	public String getContextStr(int charIndex) {
 		StringBuilder sb = new StringBuilder();
 		IndexedSourceLine line = this.getIndexedLine(charIndex);

--- a/src/aya/parser/SourceString.java
+++ b/src/aya/parser/SourceString.java
@@ -78,7 +78,7 @@ public class SourceString {
 					c = getChar(idx);
 				}
 			}
-			return new IndexedSourceLine(line.toString(), indexInLine, this.getLineNumber(charIndex));
+			return new IndexedSourceLine(line.toString(), indexInLine, this.getLineIndex(charIndex));
 		}
 	}
 	
@@ -90,7 +90,8 @@ public class SourceString {
 		return this.source;
 	}
 	
-	public int getLineNumber(int charIndex) {
+	// Zero indexed, use getLineNumber for line number
+	public int getLineIndex(int charIndex) {
 		int lineCount = 0;
 		if (this.length() > 0) {
 			for (int i = 0; i < charIndex; i++) {
@@ -100,10 +101,14 @@ public class SourceString {
 		return lineCount;
 	}
 	
+	public int getLineNumber(int charIndex) {
+		return getLineIndex(charIndex) + 1;
+	}
+	
 	
 	public int getLineCharNumber(int charIndex) {
 		IndexedSourceLine isl = this.getIndexedLine(charIndex);
-		return isl.index;
+		return isl.index + 1;
 	}
 
 	

--- a/src/aya/parser/SourceStringRef.java
+++ b/src/aya/parser/SourceStringRef.java
@@ -14,6 +14,18 @@ public class SourceStringRef {
 		return this.source.getContextStr(this.idx);
 	}
 	
+	public String getFile() {
+		return this.source.getFilename();
+	}
+	
+	public int getLineNumber() {
+		return this.source.getLineNumber(this.idx);
+	}
+	
+	public int getLineCharNumber() {
+		return this.source.getLineCharNumber(this.idx);
+	}
+	
 	public int getIndex() {
 		return this.idx;
 	}


### PR DESCRIPTION
Run a source file with the `-c` flag to check it for syntax errors. It will not actually run the file.

Print the file, line number, character number, and error message

<img width="659" height="333" alt="image" src="https://github.com/user-attachments/assets/abd0be09-00a2-4753-a0db-1c79b8529827" />



If there are no syntax errors, exit quietly

<img width="656" height="163" alt="image" src="https://github.com/user-attachments/assets/57fe7151-fa53-444d-8b28-b091fc208829" />



It currently only supports basic syntax errors and it stops after the first one found due to a limitation in the parser implementation. May update in the future.