### PR TITLE
Allow `.G` to write single bytes and lists of bytes to files

### DIFF
--- a/test/filesystem.aya
+++ b/test/filesystem.aya
@@ -84,3 +84,16 @@ img "out.png" :(image.write)
 .# Read an image
 "out.png" image.read :img;
 {img.pixels [[41 164 34 255]]} test.test
+
+.# Write bytes to a file
+[0 -1 255 -128 128 -192 64] "file.bin" 0 .G
+.# Append a byte to a file
+192 "file.bin" 1 .G
+.# Append a character to a file
+'a "file.bin" 1 .G
+
+.# Read bytes from a file
+{
+    "file.bin" :(fileutils.readallbytes) :0xff &
+    [0 -1 255 -128 128 -192 64 192 ('a :')] :0xff &
+} test.test


### PR DESCRIPTION
As suggested in discord, I have changed `.G` to allow writing bytes.
<img width="614" height="129" alt="image" src="https://github.com/user-attachments/assets/62474df3-971e-4129-ac8e-454159283c1a" />

I also allowed writing single characters and bytes for convenience.
Although performance-wise `fstream.O` should be preferred for that.

### Error Handling

TypeErrors for the filename now show the correct argument and a message.

<table>
<tr>
<td><b>before</b></td>
<td><b>after</b></td>
</tr>
<tr>
<td><pre>
aya> "test" [1] 0 .G
Type error at (.G):
.	Expected ((ASN))
.	Received (0 )
.
.
"test" [1] 0 .G
~~~~~~~~~~~~~~^
Function call traceback:
</pre></td>
<td><pre>
aya> "test" [1] 0 .G
Type error at (.G):
.	filename is not a string
.	Expected ((SSN|CSN|LSN|NSN))
.	Received ([ 1 ] )
.
.
"test" [1] 0 .G
~~~~~~~~~~~~~~^
Function call traceback:
</td></pre>
</tr>
</table>