### PR TITLE
AyaIDE: Persistent settings, redesigned Quick-Search, new search modes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -97,6 +97,11 @@
             <artifactId>json</artifactId>
             <version>20231013</version>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.18.0</version>
+        </dependency>
 
         <dependency>
             <groupId>org.teavm</groupId>

--- a/src/aya/InteractiveAya.java
+++ b/src/aya/InteractiveAya.java
@@ -7,9 +7,7 @@ import java.util.NoSuchElementException;
 import java.util.Scanner;
 
 import aya.eval.ExecutionContext;
-import aya.exceptions.parser.EndOfInputError;
 import aya.exceptions.parser.ParserException;
-import aya.exceptions.parser.SyntaxError;
 import aya.io.stdin.ScannerInputWrapper;
 import aya.obj.Obj;
 import aya.obj.block.StaticBlock;
@@ -102,8 +100,8 @@ public class InteractiveAya {
 				searchText = searchText.substring(0, searchText.length()-1);
 				
 				StaticData.getInstance().getHelpData().clearFilter();
-				StaticData.getInstance().getHelpData().applyNewFilter(searchText);
-				if(StaticData.getInstance().getHelpData().getFilteredItems().size() == 0) {
+				StaticData.getInstance().getHelpData().applyFilter(searchText);
+				if(StaticData.getInstance().getHelpData().getFilteredItems().isEmpty()) {
 					_io().out().println("No help data matching \"" + searchText + "\"");
 				} else {
 					for(String s : StaticData.getInstance().getHelpData().getFilteredItems()) {

--- a/src/aya/StaticData.java
+++ b/src/aya/StaticData.java
@@ -108,12 +108,11 @@ public class StaticData {
 			} catch (Exception e) {
 				e.printStackTrace();
 			}
-			ArrayList<String> searchList = new ArrayList<String>();
+			ArrayList<String> searchList = new ArrayList<>();
 			searchList.addAll(OpDocReader.getAllOpDescriptions());
 			// Add additional help data
 			searchList.add(AyaPrefs.CONSTANTS_HELP);
 			searchList.add(SpecialNumberParser.STR_CONSTANTS_HELP);
-			searchList.toArray(new String[searchList.size()]);
 			_helpData = new StringSearch(searchList);
 		}
 	}

--- a/src/aya/instruction/op/MiscOps.java
+++ b/src/aya/instruction/op/MiscOps.java
@@ -259,7 +259,7 @@ class OP_Help extends Operator {
 					items.mutAdd(List.fromString(a));
 				}
 			} else {
-				ArrayList<String> ss = StaticData.getInstance().getHelpData().staticSearch(s.str());
+				java.util.List<String> ss = StaticData.getInstance().getHelpData().staticSearch(s.str());
 				for (String a : ss) {
 					items.mutAdd(List.fromString(a));
 				}

--- a/src/aya/util/ColorFactory.java
+++ b/src/aya/util/ColorFactory.java
@@ -11,7 +11,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
+ *
  * You should have received a copy of the GNU General Public License along
  * with this program; if not, write to the Free Software Foundation, Inc.,
  * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
@@ -487,6 +487,19 @@ public final class ColorFactory {
 		}
 
 		return web(value);
+	}
+
+	public static String toWebString(Color color) {
+		if (color.getAlpha() < 255) {
+			return "#" + componentToString(color.getRed()) + componentToString(color.getGreen()) + componentToString(color.getBlue()) + componentToString(color.getAlpha());
+		} else {
+			return "#" + componentToString(color.getRed()) + componentToString(color.getGreen()) + componentToString(color.getBlue());
+		}
+	}
+
+	private static String componentToString(int component) {
+		String hex = Integer.toHexString(component);
+		return hex.length() == 1 ? "0" + hex : hex;
 	}
 
 	@SuppressWarnings("unused")
@@ -1408,7 +1421,7 @@ public final class ColorFactory {
 		private static Color get(String name) {
 			return namedColors.get(name);
 		}
-		
+
 		private static ArrayList<String> createNamedColorsList() {
 			ArrayList<String> names = new ArrayList<String>();
 			for (Map.Entry<String, Color> e : namedColors.entrySet()) {

--- a/src/aya/util/stringsearch/ExactMatcher.java
+++ b/src/aya/util/stringsearch/ExactMatcher.java
@@ -1,0 +1,23 @@
+package aya.util.stringsearch;
+
+import org.apache.commons.lang3.Strings;
+
+public class ExactMatcher implements StringMatcher {
+	private final boolean caseSensitive;
+	private final String needle;
+
+	public ExactMatcher(boolean caseSensitive, String needle) {
+		this.caseSensitive = caseSensitive;
+		this.needle = needle;
+	}
+
+	@Override
+	public MatchPosition[] match(String haystackItem) {
+		int matchOffset = caseSensitive
+				? haystackItem.indexOf(needle)
+				: Strings.CI.indexOf(haystackItem, needle);
+		return matchOffset < 0
+				? null
+				: new MatchPosition[]{new MatchPosition(matchOffset, needle.length())};
+	}
+}

--- a/src/aya/util/stringsearch/FuzzyMatcher.java
+++ b/src/aya/util/stringsearch/FuzzyMatcher.java
@@ -1,0 +1,175 @@
+package aya.util.stringsearch;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Stack;
+
+/**
+ * Related work:
+ * <ul>
+ *     <li><a href="https://doi.org/10.1007/978-3-540-30551-4_43">Minimum Common String Partition</a> is superficially similar, but searches for matching permutations of partitions of two strings.</li>
+ *     <li><a href="https://doi.org/10.1137/0206024">Fast Pattern Matching in Strings</a> (the KMP algorithm)</li>
+ * </ul>
+ * <br/> Whereas this algorithm searches for matching subsequences of partitions.
+ */
+public class FuzzyMatcher implements StringMatcher {
+	private final String needle;
+	private final char[] needleChars;
+	private final boolean caseSensitive;
+	private final Map<Integer, int[]> kmpNextByNeedleOffset = new HashMap<>();
+
+	public static void main(String[] args) {
+		FuzzyMatcher matcher = new FuzzyMatcher(false, "abcab");
+		for (MatchPosition position : matcher.match("ab_cab_abc_a_b")) {
+			System.out.println("o=" + position.offset + " l=" + position.length);
+		}
+	}
+
+	public FuzzyMatcher(boolean caseSensitive, String needle) {
+		this.needle = caseSensitive ? needle : needle.toLowerCase(); // lazy hack :(
+		this.needleChars = needle.toCharArray();
+		this.caseSensitive = caseSensitive;
+	}
+
+	@Override
+	public MatchPosition[] match(String haystackItem) {
+		if (!caseSensitive)
+			haystackItem = haystackItem.toLowerCase();
+
+		Stack<MatchPosition> bestMatch = new Stack<>();
+		int numGroups = findMinimumPartition(0, haystackItem, 0, Integer.MAX_VALUE, bestMatch);
+		assert numGroups < 0 || numGroups == bestMatch.size();
+		return numGroups < 0
+				? null
+				: bestMatch.toArray(new MatchPosition[numGroups]);
+	}
+
+	/**
+	 * @return -1 if no matching partition was found. Otherwise, the number of groups needed to match the haystack.
+	 */
+	private int findMinimumPartition(int needleOffset, String haystackItem, int haystackOffset, int maxGroups, Stack<MatchPosition> resultContainer) {
+		if (needleOffset >= needle.length()) {
+			return 0; // needle matched completely
+		}
+		if (maxGroups <= 0) {
+			return -1;
+		}
+		if (!canMatch(needleOffset, haystackItem, haystackOffset)) {
+			return -1;
+		}
+
+		/* Greedily matching the longest prefix does not work.
+		 *   For example: needle=abcab haystack=ab_cab_abc_a_b
+		 *   BAD: [abc a b]
+		 *   GOOD: [ab cab]
+		 */
+
+		List<Integer> matchingPrefixes = findAllMatchingPrefixes(needleOffset, haystackItem, haystackOffset);
+		int prevMatchIdx = -1;
+		int minSuffixGroups = Integer.MAX_VALUE;
+		MatchPosition minSuffixMatch = null;
+		for (int i = matchingPrefixes.size() - 1; i >= 0; i--) {
+			int matchLen = i + 1;
+			int matchIndex = matchingPrefixes.get(i);
+			if (prevMatchIdx == matchIndex) {
+				continue; // ignore this match, because the previous (longer) match at the same position will always give a better result
+			}
+			prevMatchIdx = matchIndex;
+
+			int suffixGroups = findMinimumPartition(needleOffset + matchLen, haystackItem, matchIndex + matchLen, maxGroups - 1, resultContainer);
+			if (suffixGroups < 0) {
+				continue;
+			}
+			if (minSuffixMatch != null) {
+				// remove the partial result that was pushed by the previous best match
+				resultContainer.setSize(resultContainer.size() - minSuffixGroups);
+			}
+
+			minSuffixGroups = suffixGroups;
+			minSuffixMatch = new MatchPosition(matchIndex, matchLen);
+			maxGroups = minSuffixGroups; // restrict search such that only better solutions are explored
+			if (suffixGroups <= 1)
+				break; // best possible result, stop searching
+		}
+
+		if (minSuffixMatch != null) {
+			resultContainer.add(0, minSuffixMatch);
+			return minSuffixGroups + 1;
+		}
+		return -1;
+	}
+
+	private boolean canMatch(int needleOffset, String haystackItem, int haystackOffset) {
+		int needleLenRemain = needle.length() - needleOffset;
+		if ((haystackOffset + needleLenRemain) > haystackItem.length()) {
+			return false; // remaining haystackItem is too short to match the remaining needle
+		}
+
+		char needleChar = needleChars[needleOffset];
+		while (haystackOffset < haystackItem.length()) {
+			if (needleChar == haystackItem.charAt(haystackOffset)) {
+				needleOffset++;
+				if (needle.length() == needleOffset)
+					return true;
+				needleChar = needleChars[needleOffset];
+			}
+			haystackOffset++;
+		}
+		return false;
+	}
+
+	private List<Integer> findAllMatchingPrefixes(int needleOffset, String haystackItem, int haystackOffset) {
+		// This uses a minor variation of the KMP algorithm to efficiently find all prefixes.
+		List<Integer> result = new ArrayList<>(needleChars.length);
+		int len_needle = needleChars.length - needleOffset;
+		assert len_needle > 0;
+
+		int i_needle = 0;
+		int len_hay = haystackItem.length();
+		int[] kmp_next = getKmpNextTable(needleOffset);
+		while (haystackOffset < len_hay) {
+			char c_hay = haystackItem.charAt(haystackOffset);
+			if (c_hay == needleChars[i_needle + needleOffset]) {
+				if (result.size() <= i_needle) {
+					// found a new longest prefix
+					result.add(haystackOffset - i_needle);
+					if ((i_needle + 1) == len_needle) {
+						break; // matched entire needle
+					}
+				}
+			} else {
+				do {
+					i_needle = kmp_next[i_needle];
+				} while (i_needle >= 0 && c_hay != needleChars[i_needle]);
+			}
+			i_needle++;
+			haystackOffset++;
+		}
+		return result;
+	}
+
+	private int[] getKmpNextTable(int needleOffset) {
+		return kmpNextByNeedleOffset.computeIfAbsent(needleOffset, k -> {
+			if (needle.isEmpty()) {
+				return new int[0];
+			} else {
+				int[] kmp_next = new int[needleChars.length];
+				kmp_next[0] = -1;
+				int i_needle = 1;
+				int i_check = 0;
+				while (i_needle < needleChars.length) {
+					if (needleChars[i_needle] == needleChars[i_check]) {
+						kmp_next[i_needle] = kmp_next[i_check];
+					} else {
+						kmp_next[i_needle] = i_check;
+					}
+					i_needle++;
+					i_check++;
+				}
+				return kmp_next;
+			}
+		});
+	}
+}

--- a/src/aya/util/stringsearch/MatchInfo.java
+++ b/src/aya/util/stringsearch/MatchInfo.java
@@ -1,0 +1,19 @@
+package aya.util.stringsearch;
+
+public class MatchInfo {
+	/**
+	 * The index into the haystack. (points at the matched item)
+	 */
+	// Note: I am preferring the 'index' over the haystack string here, because this makes some optimizations easier.
+	// For example: creating a list of GUI Items for the haystack and toggling their visibility based on matches.
+	public final int index;
+	/**
+	 * The substrings of the haystack-item that caused the match.
+	 */
+	public final MatchPosition[] matchPositions;
+
+	public MatchInfo(int index, MatchPosition... matchPositions) {
+		this.index = index;
+		this.matchPositions = matchPositions;
+	}
+}

--- a/src/aya/util/stringsearch/MatchPosition.java
+++ b/src/aya/util/stringsearch/MatchPosition.java
@@ -1,0 +1,11 @@
+package aya.util.stringsearch;
+
+public class MatchPosition {
+	public final int offset;
+	public final int length;
+
+	public MatchPosition(int offset, int length) {
+		this.offset = offset;
+		this.length = length;
+	}
+}

--- a/src/aya/util/stringsearch/RegexMatcher.java
+++ b/src/aya/util/stringsearch/RegexMatcher.java
@@ -1,0 +1,29 @@
+package aya.util.stringsearch;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class RegexMatcher implements StringMatcher {
+	private final Pattern needle;
+
+	private static Pattern compilePatternSafe(boolean caseSensitive, String pattern) {
+		try {
+			return caseSensitive ? Pattern.compile(pattern) : Pattern.compile(pattern, Pattern.CASE_INSENSITIVE);
+		} catch (Exception e) {
+			pattern = Pattern.quote(pattern);
+			return caseSensitive ? Pattern.compile(pattern) : Pattern.compile(pattern, Pattern.CASE_INSENSITIVE);
+		}
+	}
+
+	public RegexMatcher(boolean caseSensitive, String needle) {
+		this.needle = compilePatternSafe(caseSensitive, needle);
+	}
+
+	@Override
+	public MatchPosition[] match(String haystackItem) {
+		Matcher matcher = needle.matcher(haystackItem);
+		return matcher.find()
+				? new MatchPosition[]{new MatchPosition(matcher.start(), matcher.end() - matcher.start())}
+				: null;
+	}
+}

--- a/src/aya/util/stringsearch/SearchMode.java
+++ b/src/aya/util/stringsearch/SearchMode.java
@@ -1,0 +1,28 @@
+package aya.util.stringsearch;
+
+public enum SearchMode {
+	Exact(ExactMatcher::new),
+	Regex(RegexMatcher::new),
+	/**
+	 * This matches by splitting the needle into a minimal set of parts that match the haystack sequentially.
+	 * For example:
+	 * <pre>
+	 * needle = "foba"
+	 * haystack = [
+	 *   "FooBar"
+	 *    ^^ ^^      1 split
+	 *   "FizzOrBar"
+	 *    ^   ^ ^^   2 splits
+	 *   "FizzOrFoBar"
+	 *          ^^^^ 0 splits
+	 * ]
+	 * </pre>
+	 */
+	Fuzzy(FuzzyMatcher::new);
+
+	public final StringMatcherFactory matcherFactory;
+
+	SearchMode(StringMatcherFactory matcherFactory) {
+		this.matcherFactory = matcherFactory;
+	}
+}

--- a/src/aya/util/stringsearch/StringMatcher.java
+++ b/src/aya/util/stringsearch/StringMatcher.java
@@ -1,0 +1,10 @@
+package aya.util.stringsearch;
+
+@FunctionalInterface
+public interface StringMatcher {
+	/**
+	 * @param haystackItem the string to match against
+	 * @return {@code null} if no match was found. Otherwise, a list of Positions that constitute the match.
+	 */
+	MatchPosition[] match(String haystackItem);
+}

--- a/src/aya/util/stringsearch/StringMatcherFactory.java
+++ b/src/aya/util/stringsearch/StringMatcherFactory.java
@@ -1,0 +1,9 @@
+package aya.util.stringsearch;
+
+@FunctionalInterface
+public interface StringMatcherFactory {
+	/**
+	 * @param needle the string to match with
+	 */
+	StringMatcher createMatcher(boolean caseSensitive, String needle);
+}

--- a/src/ui/CodeTextPane.java
+++ b/src/ui/CodeTextPane.java
@@ -164,7 +164,7 @@ public class CodeTextPane extends JTextPane {
 	public void tabPressed() {
 		if (inFocus) {
 			int carat = getCaretPosition();
-			int offset = (carat-14)>0 ? carat-14 : 0;
+			int offset = Math.max((carat - 14), 0);
 			String s = null;
 			try {
 				s = getDocument().getText(offset, carat-offset);

--- a/src/ui/QuickSearch.java
+++ b/src/ui/QuickSearch.java
@@ -1,45 +1,74 @@
 package ui;
+
 import java.awt.BorderLayout;
+import java.awt.Component;
 import java.awt.Dimension;
-import java.awt.GridBagConstraints;
-import java.awt.GridBagLayout;
+import java.awt.event.ComponentAdapter;
+import java.awt.event.ComponentEvent;
 import java.awt.event.KeyEvent;
 import java.awt.event.KeyListener;
+import java.awt.event.MouseEvent;
+import java.awt.event.MouseListener;
 import java.awt.event.WindowAdapter;
 import java.awt.event.WindowEvent;
+import java.io.PrintStream;
+import java.util.List;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import javax.swing.BorderFactory;
+import javax.swing.Box;
+import javax.swing.BoxLayout;
+import javax.swing.JButton;
+import javax.swing.JCheckBox;
+import javax.swing.JComboBox;
+import javax.swing.JComponent;
 import javax.swing.JFrame;
+import javax.swing.JLabel;
 import javax.swing.JPanel;
+import javax.swing.JPopupMenu;
 import javax.swing.JScrollPane;
+import javax.swing.JSpinner;
+import javax.swing.JSplitPane;
 import javax.swing.JTextArea;
 import javax.swing.ScrollPaneConstants;
+import javax.swing.SpinnerNumberModel;
 import javax.swing.border.CompoundBorder;
 import javax.swing.border.EmptyBorder;
+import javax.swing.text.BadLocationException;
+import javax.swing.text.DefaultHighlighter.DefaultHighlightPainter;
+import javax.swing.text.LayeredHighlighter.LayerPainter;
 
+import aya.StaticData;
 import aya.util.StringSearch;
+import aya.util.stringsearch.MatchInfo;
+import aya.util.stringsearch.MatchPosition;
+import aya.util.stringsearch.SearchMode;
+import ui.settings.QuickSearchSettings;
+import ui.settings.SettingsManager;
 
 
-@SuppressWarnings("serial")
 public class QuickSearch extends JPanel {
+	// Pro: this prevents the slow Swing rendering from blocking input, making the UI feel less laggy while typing.
+	// Con: UI might feel less responsive on fast machines.
+	private static final int reRenderTimeoutMillis = 150;
+	// Avoid hammering the filesystem just because the user is fiddling with the window size.
+	private static final int configSaveTimeoutMillis = 5000;
 
-	private int maxItemsToDisplay = 35;
-	
-	private static final int WIDTH = 400;
-	
 	private static final CompoundBorder BORDER = new CompoundBorder(
-			BorderFactory.createMatteBorder(2,0,2,4,StyleTheme.DEFAULT.getBgColor()), new EmptyBorder(3, 5, 3, 5));
-	
-	
-	
-	private JScrollPane scrollResults;
-	private CodeTextPane searchBar = new CodeTextPane();
-	private JPanel results = new JPanel();
-	private StringSearch strings;
-	private GridBagConstraints gbc = new GridBagConstraints();
-	
+			BorderFactory.createMatteBorder(2, 0, 2, 4, StyleTheme.DEFAULT.getBgColor()),
+			new EmptyBorder(3, 5, 3, 5)
+	);
+	private static final CompoundBorder BORDER_HIGHLIGHT = new CompoundBorder(
+			BorderFactory.createMatteBorder(2, 0, 2, 4, getSettings().getHighlightColor()),
+			new EmptyBorder(3, 5, 3, 5)
+	);
+
 	public static JFrame activeFrame;
 	public static QuickSearch activeQuickSearch;
+
 	public static void newQSFrame(String[] data) {
 		activeFrame = new JFrame("Quick Search");
 		activeQuickSearch = new QuickSearch(data);
@@ -47,163 +76,430 @@ public class QuickSearch extends JPanel {
 		activeFrame.pack();
 		activeFrame.setVisible(true);
 		activeFrame.setDefaultCloseOperation(JFrame.DO_NOTHING_ON_CLOSE);
-		activeFrame.addWindowListener(new WindowAdapter(){
-            public void windowClosing(WindowEvent e){
-                activeFrame.setVisible(false);
-            }
-        });
+		activeFrame.addWindowListener(new WindowAdapter() {
+			public void windowClosing(WindowEvent e) {
+				activeFrame.setVisible(false);
+			}
+		});
 	}
+
 	public static boolean isFrameActive() {
 		return activeFrame != null;
 	}
+
 	public static void frameFocus() {
 		activeFrame.setVisible(true);
 		activeQuickSearch.grabFocus();
 	}
 
-	
+	private static QuickSearchSettings getSettings() {
+		return SettingsManager.getUiSettings().getQuickSearch();
+	}
+
+	private static StringSearch initStringSearch(String[] strings) {
+		StringSearch result = new StringSearch(strings);
+		result.setSearchMode(getSettings().getSearchMode());
+		result.setCaseSensitive(getSettings().isCaseSensitive());
+		return result;
+	}
+
+	private final JScrollPane scrollResults;
+	private final CodeTextPane searchBar = new CodeTextPane();
+	private final JPanel results = new JPanel();
+	private final StringDisplay detailsPanel;
+
+	private int maxItemsToDisplay = Integer.MAX_VALUE;
+	private StringSearch strings;
+	private Timer reRenderTimer;
+	private Timer configSaveTimer;
+	private int currentSelection;
+
 	public QuickSearch(String[] stringList) {
-		this.strings = new StringSearch(stringList);
-		
-		//Size
-		setMaximumSize(new Dimension(WIDTH, 500));
-		setMinimumSize(new Dimension(WIDTH, 500));
-		setPreferredSize(new Dimension(WIDTH, 500));
-		
+		this.strings = initStringSearch(stringList);
+
 		//Border
 		setBorder(new CompoundBorder(BorderFactory.createMatteBorder(5, 5, 5, 5, StyleTheme.ACCENT_COLOR), BorderFactory.createMatteBorder(5, 5, 5, 5, StyleTheme.DEFAULT.getBgColor())));
 
-		
 		//Layout
 		setLayout(new BorderLayout());
-		
+
 		//KeyListeners
 		KeyListener keyListener = new KeyListener() {
 			public void keyPressed(KeyEvent arg0) {
-				if(arg0.getKeyChar()==KeyEvent.VK_TAB) {
-					searchBar.tabPressed();
+				switch (arg0.getKeyCode()) {
+					case KeyEvent.VK_TAB:
+						searchBar.tabPressed();
+						break;
+					case KeyEvent.VK_DOWN:
+						changeSelection(1);
+						break;
+					case KeyEvent.VK_UP:
+						changeSelection(-1);
+						break;
+					default:
+						return;
+				}
+				arg0.consume();
+			}
+
+			public void keyReleased(KeyEvent arg0) {
+				if (arg0.isControlDown())
+					return;
+				switch (arg0.getKeyCode()) {
+					case KeyEvent.VK_TAB:
+					case KeyEvent.VK_DOWN:
+					case KeyEvent.VK_UP:
+						arg0.consume();
+						break;
+					default:
+						startReRenderTimer();
+						break;
 				}
 			}
-			public void keyReleased(KeyEvent arg0) {
-				if(arg0.isControlDown())
-					return;
-				strings.appendToFilter(searchBar.getText());
-				refreshList();
-				scrollToTop();
+
+			public void keyTyped(KeyEvent arg0) {
 			}
-			public void keyTyped(KeyEvent arg0) {}
 		};
-		
-		//Search Bar
+
+		JPanel topPanel = new JPanel();
+		topPanel.setLayout(new BoxLayout(topPanel, BoxLayout.X_AXIS));
+		topPanel.setBackground(StyleTheme.DEFAULT.getBgColor());
+		add(topPanel, BorderLayout.NORTH);
+		Dimension topPadding = new Dimension(6, 0);
+
+		// TopPanel -> Search Bar
 		searchBar.addKeyListener(keyListener);
 		searchBar.setPreferredSize(new Dimension(10, 20));
-		add(searchBar, BorderLayout.NORTH);
-		
-		//Results & Layout
-		results.setLayout(new GridBagLayout());
-		gbc.fill = GridBagConstraints.HORIZONTAL;
-		gbc.weightx=1.0;
-		results = new JPanel();
-		results.setLayout(new GridBagLayout());
-		
-		
-		
-		//Wrap the results pane so the results stay at the top
+		topPanel.add(searchBar, BorderLayout.NORTH);
+
+		// TopPanel -> Cc Checkbox
+		JCheckBox ccCheckbox = new JCheckBox("Cc", getSettings().isCaseSensitive());
+		ccCheckbox.setBackground(StyleTheme.DEFAULT.getBgColor());
+		ccCheckbox.setForeground(StyleTheme.DEFAULT.getFgColor());
+		topPanel.add(Box.createRigidArea(topPadding));
+		topPanel.add(ccCheckbox);
+		ccCheckbox.addActionListener(e -> {
+			boolean caseSensitive = ccCheckbox.isSelected();
+			strings.setCaseSensitive(caseSensitive);
+			getSettings().setCaseSensitive(caseSensitive);
+			startConfigSaveTimer();
+			startReRenderTimer();
+		});
+
+		// TopPanel -> searchMode combobox
+		JComboBox<SearchMode> searchModeCombo = new JComboBox<>(SearchMode.values());
+		searchModeCombo.setSelectedItem(getSettings().getSearchMode());
+		searchModeCombo.setForeground(StyleTheme.DEFAULT.getFgColor());
+		searchModeCombo.setBackground(StyleTheme.DEFAULT.getBgColor());
+		topPanel.add(Box.createRigidArea(topPadding));
+		topPanel.add(searchModeCombo);
+		searchModeCombo.addActionListener(e -> {
+			SearchMode newSearchMode = (SearchMode) searchModeCombo.getSelectedItem();
+			strings.setSearchMode(newSearchMode);
+			getSettings().setSearchMode(newSearchMode);
+			startConfigSaveTimer();
+			startReRenderTimer();
+		});
+
+		// TopPanel -> extra options
+		JButton extraOptsButton = new JButton("...");
+		extraOptsButton.setForeground(StyleTheme.DEFAULT.getFgColor());
+		extraOptsButton.setBackground(StyleTheme.DEFAULT.getBgColor());
+		extraOptsButton.setPreferredSize(new Dimension(20, 20));
+		JPopupMenu extraOptsMenu = new JPopupMenu();
+		extraOptsMenu.setForeground(StyleTheme.DEFAULT.getFgColor());
+		extraOptsMenu.setBackground(StyleTheme.DEFAULT.getBgColor());
+		extraOptsMenu.setBorder(new EmptyBorder(6, 8, 6, 8));
+		topPanel.add(Box.createRigidArea(topPadding));
+		topPanel.add(extraOptsButton);
+		extraOptsButton.addActionListener(e -> {
+			// first, open the popup without showing it to determine the size
+			extraOptsMenu.setVisible(false);
+			extraOptsMenu.show(extraOptsButton, 0, 0);
+			// then position it correctly
+			javax.swing.SwingUtilities.invokeLater(() -> {
+				extraOptsMenu.show(extraOptsButton, extraOptsButton.getWidth() - extraOptsMenu.getWidth(), extraOptsButton.getHeight());
+				extraOptsMenu.setVisible(true);
+			});
+		});
+
+		// TopPanel -> extra options -> number-input 'Summary Lines'
+		JPanel summaryLinesOptRow = new JPanel();
+		summaryLinesOptRow.setLayout(new BoxLayout(summaryLinesOptRow, BoxLayout.X_AXIS));
+		summaryLinesOptRow.setBackground(StyleTheme.DEFAULT.getBgColor());
+		JLabel summaryLinesLabel = new JLabel("Summary Lines");
+		summaryLinesLabel.setForeground(StyleTheme.DEFAULT.getFgColor());
+		summaryLinesLabel.setBackground(StyleTheme.DEFAULT.getBgColor());
+		getSettings().setSummaryLines(Math.max(0, Math.min(99, getSettings().getSummaryLines())));
+		JSpinner summaryLinesSpinner = new JSpinner(new SpinnerNumberModel(getSettings().getSummaryLines(), 0, 99, 1));
+		summaryLinesSpinner.addChangeListener(e -> {
+			int newNumSummaryLines = (int) summaryLinesSpinner.getValue();
+			getSettings().setSummaryLines(newNumSummaryLines);
+			startConfigSaveTimer();
+			startReRenderTimer();
+		});
+		summaryLinesOptRow.add(summaryLinesLabel);
+		summaryLinesOptRow.add(Box.createRigidArea(topPadding));
+		summaryLinesOptRow.add(summaryLinesSpinner);
+		extraOptsMenu.add(summaryLinesOptRow);
+
+		// Main Content Split
+		JSplitPane resultSplitPane = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT);
+		resultSplitPane.setResizeWeight(0.5);
+		add(resultSplitPane);
+
+		// Main Content Split -> Summary -> Result Items
+		results.setLayout(new BoxLayout(results, BoxLayout.Y_AXIS));
+
+		// Wrap the results pane so the results stay at the top
 		JPanel resultsWrapper = new JPanel();
 		resultsWrapper.setBackground(StyleTheme.DEFAULT.getBgColor());
 		resultsWrapper.setLayout(new BorderLayout());
 		resultsWrapper.add(results, BorderLayout.NORTH);
 
-		//Wrap the results in a scroll pane
+		// Main Content Split -> Summary
+		// Wrap the results in a scroll pane
 		scrollResults = new JScrollPane(resultsWrapper);
 		scrollResults.setBackground(StyleTheme.DEFAULT.getBgColor());
 		scrollResults.setBorder(BorderFactory.createEmptyBorder());
 		scrollResults.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
-		//scrollResults.getVerticalScrollBar().setBackground(StyleTheme.DEFAULT.getBgColor());
+		scrollResults.setHorizontalScrollBarPolicy(ScrollPaneConstants.HORIZONTAL_SCROLLBAR_NEVER);
 		scrollResults.getVerticalScrollBar().setBorder(BorderFactory.createEmptyBorder());
-		add(scrollResults);
-		
-		//Put items in list
-		refreshList();
-		scrollToTop();
-		
+		Dimension summarySize = new Dimension(getSettings().getSummaryPanelWidth(), getSettings().getPanelHeight());
+		scrollResults.setPreferredSize(summarySize);
+		scrollResults.getViewport().addComponentListener(new ComponentAdapter() {
+			@Override
+			public void componentResized(ComponentEvent e) {
+				getSettings().setSummaryPanelWidth(scrollResults.getWidth());
+				getSettings().setPanelHeight(scrollResults.getHeight());
+				startConfigSaveTimer();
+
+				Component viewPort = e.getComponent();
+				int width = viewPort.getWidth();
+				for (Component component : results.getComponents()) {
+					component.setSize(width, component.getHeight());
+				}
+			}
+		});
+		resultSplitPane.add(scrollResults);
+
+		// Main Content Split -> Details
+		detailsPanel = new StringDisplay();
+		JScrollPane detailScroll = new JScrollPane(detailsPanel);
+		detailScroll.setBackground(StyleTheme.DEFAULT.getBgColor());
+		detailScroll.setBorder(BorderFactory.createEmptyBorder());
+		detailScroll.setVerticalScrollBarPolicy(ScrollPaneConstants.VERTICAL_SCROLLBAR_ALWAYS);
+		detailScroll.getVerticalScrollBar().setBorder(BorderFactory.createEmptyBorder());
+		Dimension detailSize = new Dimension(getSettings().getDetailPanelWidth(), getSettings().getPanelHeight());
+		detailScroll.setPreferredSize(detailSize);
+		detailScroll.getViewport().addComponentListener(new ComponentAdapter() {
+			@Override
+			public void componentResized(ComponentEvent e) {
+				getSettings().setDetailPanelWidth(detailScroll.getWidth());
+				getSettings().setPanelHeight(detailScroll.getHeight());
+				startConfigSaveTimer();
+			}
+		});
+		resultSplitPane.add(detailScroll);
+
+		doReRender();
 	}
-	
+
 	public static void updateHelpTextInFrame(String[] strs) {
 		activeQuickSearch.updateHelpText(strs);
 	}
-	
+
 	public void updateHelpText(String[] strings) {
-		String currentSearch = this.strings.getFilter();
-		this.strings = new StringSearch(strings);
-		this.strings.applyNewFilter(currentSearch);
-		refreshList();
+		this.strings = initStringSearch(strings);
+		doReRender();
 	}
-	
-	/** Sets the maximum number of items to display in the list 
-	 * (default is 25) */
+
+	/**
+	 * Sets the maximum number of items to display in the list
+	 * (default is unlimited)
+	 */
 	public void setMaxItemsToDisplay(int max) {
 		maxItemsToDisplay = max;
 	}
-	
-	/** Sets the current list */
-	public void setList(String[] list) {
-		this.strings = new StringSearch(list);
-		refreshList();
+
+	private void setCurrentSelection(int newSelection) {
+		Component[] resultItems = results.getComponents();
+		if (currentSelection >= 0 && currentSelection < resultItems.length)
+			((JComponent) resultItems[currentSelection]).setBorder(BORDER);
+		if (newSelection >= 0 && newSelection < resultItems.length)
+			((JComponent) resultItems[newSelection]).setBorder(BORDER_HIGHLIGHT);
+
+		this.currentSelection = newSelection;
+		scrollToSelection();
+		List<MatchInfo> matches = strings.getMatches();
+		if (newSelection >= 0 && newSelection < matches.size()) {
+			MatchInfo match = matches.get(newSelection);
+			String fullText = strings.getItem(match);
+			detailsPanel.updateContent(fullText, match);
+		} else {
+			detailsPanel.updateContent("", null);
+		}
 	}
-	
-	/** Runs the search bars as a filter on the strings and then updates
+
+	/**
+	 * Sets the current list
+	 */
+	public void setList(String[] list) {
+		this.strings = initStringSearch(list);
+		doReRender();
+	}
+
+	private void startReRenderTimer() {
+		if (reRenderTimer != null) {
+			reRenderTimer.cancel();
+		}
+		reRenderTimer = new Timer();
+		reRenderTimer.schedule(new TimerTask() {
+			@Override
+			public void run() {
+				doReRender();
+			}
+		}, reRenderTimeoutMillis);
+	}
+
+	private void startConfigSaveTimer() {
+		if (configSaveTimer != null) {
+			configSaveTimer.cancel();
+		}
+		configSaveTimer = new Timer();
+		configSaveTimer.schedule(new TimerTask() {
+			@Override
+			public void run() {
+				SettingsManager.saveUiSettings();
+			}
+		}, configSaveTimeoutMillis);
+	}
+
+	private void doReRender() {
+		// remember the item that was referenced previously
+		Integer previousSelectionRawIdx = strings.getMatches().stream().skip(currentSelection).map(x -> x.index).findFirst().orElse(null);
+		strings.applyFilter(searchBar.getText());
+		strings.sortFilterResults();
+		refreshList();
+
+		// Find the previously selected item in the new filtered list
+		if (previousSelectionRawIdx != null) {
+			setCurrentSelection(
+					IntStream.range(0, strings.getMatches().size())
+							.filter(i -> strings.getMatches().get(i).index == previousSelectionRawIdx)
+							.findFirst().orElse(0)
+			);
+		} else {
+			setCurrentSelection(0);
+		}
+	}
+
+	private void changeSelection(int delta) {
+		int newSelection = Math.max(0, Math.min(strings.getMatches().size() - 1, currentSelection + delta));
+		if (newSelection == currentSelection)
+			return;
+		setCurrentSelection(newSelection);
+	}
+
+	/**
+	 * Runs the search bars as a filter on the strings and then updates
 	 * the newly added strings
 	 */
 	public void refreshList() {
 		results.removeAll();
-		gbc.gridx = 0;
-		gbc.gridy = 0;
-
-		int itemsToDisplay = strings.getFilteredItems().size();
-		if(itemsToDisplay > maxItemsToDisplay) {
-			itemsToDisplay = maxItemsToDisplay;
-		}
-		
-		
-		for(int i = 0; i < itemsToDisplay; i++) {
-			gbc.gridy++;
-			results.add(new StringDisplay(strings.getFilteredItems().get(i)), gbc);
-		}
-		results.validate();
-		results.repaint();
+		IntStream.range(0, strings.getMatches().size())
+				.limit(maxItemsToDisplay)
+				.forEach(i -> {
+					MatchInfo match = strings.getMatches().get(i);
+					String summaryText = strings.getItem(match).lines()
+							.limit(getSettings().getSummaryLines() == 0 ? Integer.MAX_VALUE : getSettings().getSummaryLines())
+							.collect(Collectors.joining(System.lineSeparator()));
+					StringDisplay strDisplay = new StringDisplay(i, summaryText, match, i == currentSelection);
+					results.add(strDisplay);
+					strDisplay.addMouseListener(strDisplay);
+				});
 		scrollResults.validate();
 		scrollResults.repaint();
 	}
-	
-	/** Scrolls to the top of the list */
-	public void scrollToTop() {
-		javax.swing.SwingUtilities.invokeLater(new Runnable() {
-		   public void run() { 
-		       scrollResults.getVerticalScrollBar().setValue(0);
-		   }
-		});
+
+	private void scrollToSelection() {
+		if (currentSelection == 0) {
+			javax.swing.SwingUtilities.invokeLater(() -> scrollResults.getVerticalScrollBar().setValue(0));
+		} else {
+			javax.swing.SwingUtilities.invokeLater(() -> results.scrollRectToVisible(results.getComponent(currentSelection).getBounds()));
+		}
 	}
-	
+
 	@Override
 	public void grabFocus() {
 		searchBar.grabFocus();
 	}
-	
-	public class StringDisplay extends JTextArea {
-		
-		StringDisplay(String str) {
-			super(0,0);
-			this.setText(str);
+
+	private static LayerPainter searchHighlightPainter;
+
+	private static LayerPainter getSearchHighlightPainter() {
+		if (searchHighlightPainter == null) {
+			searchHighlightPainter = new DefaultHighlightPainter(getSettings().getHighlightColor());
+		}
+		return searchHighlightPainter;
+	}
+
+	public class StringDisplay extends JTextArea implements MouseListener {
+		private final int itemIdx;
+
+		StringDisplay() {
+			this(-1, "", null, false);
+		}
+
+		StringDisplay(int itemIdx, String str, MatchInfo matchInfo, boolean highlight) {
+			super(0, 0);
+			this.itemIdx = itemIdx;
 			this.setWrapStyleWord(true);
 			this.setLineWrap(true);
 			this.setFont(StyleTheme.MONO_11);
 			this.setBackground(StyleTheme.ACCENT_COLOR);
 			this.setForeground(StyleTheme.DEFAULT.getFgColor());
-			this.setBorder(QuickSearch.BORDER);
+			this.setBorder(highlight ? QuickSearch.BORDER_HIGHLIGHT : QuickSearch.BORDER);
 			this.setEditable(false);
-			
+			updateContent(str, matchInfo);
 		}
-			
+
+		public void updateContent(String text, MatchInfo matchInfo) {
+			this.setText(text);
+			if (matchInfo != null && matchInfo.matchPositions != null) {
+				for (MatchPosition matchPosition : matchInfo.matchPositions) {
+					try {
+						// surprisingly, this works for the summary fields without any extra bounds checks
+						this.getHighlighter().addHighlight(matchPosition.offset, matchPosition.offset + matchPosition.length, getSearchHighlightPainter());
+					} catch (BadLocationException e) {
+						try (PrintStream err = StaticData.IO.err()) {
+							err.println("StringSearch yielded an invalid match position (" + matchPosition + ")" + e.getMessage());
+							e.printStackTrace(err);
+						}
+					}
+				}
+			}
+		}
+
+		@Override
+		public void mouseClicked(MouseEvent e) {
+		}
+
+		@Override
+		public void mousePressed(MouseEvent e) {
+		}
+
+		@Override
+		public void mouseReleased(MouseEvent e) {
+			QuickSearch.this.setCurrentSelection(itemIdx);
+		}
+
+		@Override
+		public void mouseEntered(MouseEvent e) {
+		}
+
+		@Override
+		public void mouseExited(MouseEvent e) {
+		}
 	}
 }

--- a/src/ui/settings/ISettings.java
+++ b/src/ui/settings/ISettings.java
@@ -1,0 +1,9 @@
+package ui.settings;
+
+import org.json.JSONObject;
+
+public interface ISettings {
+	void loadFromJson(JSONObject storedSettings);
+
+	JSONObject storeToJson();
+}

--- a/src/ui/settings/QuickSearchSettings.java
+++ b/src/ui/settings/QuickSearchSettings.java
@@ -14,6 +14,7 @@ public class QuickSearchSettings implements ISettings {
 	private int detailPanelWidth = 400;
 	private int panelHeight = 500;
 	private int summaryLines = 1;
+	private boolean showDetailsPanel = true;
 
 	public SearchMode getSearchMode() {
 		return searchMode;
@@ -71,6 +72,14 @@ public class QuickSearchSettings implements ISettings {
 		this.summaryLines = summaryLines;
 	}
 
+	public boolean isShowDetailsPanel() {
+		return showDetailsPanel;
+	}
+
+	public void setShowDetailsPanel(boolean showDetailsPanel) {
+		this.showDetailsPanel = showDetailsPanel;
+	}
+
 	@Override
 	public void loadFromJson(JSONObject storedSettings) {
 		searchMode = storedSettings.optEnum(SearchMode.class, "searchMode", searchMode);
@@ -82,6 +91,7 @@ public class QuickSearchSettings implements ISettings {
 		detailPanelWidth = storedSettings.optInt("detailPanelWidth", detailPanelWidth);
 		panelHeight = storedSettings.optInt("panelHeight", panelHeight);
 		summaryLines = storedSettings.optInt("summaryLines", summaryLines);
+		showDetailsPanel = storedSettings.optBoolean("showDetailsPanel", showDetailsPanel);
 	}
 
 	@Override
@@ -94,6 +104,7 @@ public class QuickSearchSettings implements ISettings {
 		result.put("detailPanelWidth", detailPanelWidth);
 		result.put("panelHeight", panelHeight);
 		result.put("summaryLines", summaryLines);
+		result.put("showDetailsPanel", showDetailsPanel);
 		return result;
 	}
 }

--- a/src/ui/settings/QuickSearchSettings.java
+++ b/src/ui/settings/QuickSearchSettings.java
@@ -1,0 +1,99 @@
+package ui.settings;
+
+import aya.util.ColorFactory;
+import aya.util.stringsearch.SearchMode;
+import org.json.JSONObject;
+
+import java.awt.Color;
+
+public class QuickSearchSettings implements ISettings {
+	private SearchMode searchMode = SearchMode.Exact;
+	private boolean caseSensitive = true;
+	private Color highlightColor = new Color(255, 255, 0, 64);
+	private int summaryPanelWidth = 200;
+	private int detailPanelWidth = 400;
+	private int panelHeight = 500;
+	private int summaryLines = 1;
+
+	public SearchMode getSearchMode() {
+		return searchMode;
+	}
+
+	public void setSearchMode(SearchMode searchMode) {
+		this.searchMode = searchMode;
+	}
+
+	public boolean isCaseSensitive() {
+		return caseSensitive;
+	}
+
+	public void setCaseSensitive(boolean caseSensitive) {
+		this.caseSensitive = caseSensitive;
+	}
+
+	public Color getHighlightColor() {
+		return highlightColor;
+	}
+
+	public void setHighlightColor(Color highlightColor) {
+		this.highlightColor = highlightColor;
+	}
+
+	public int getSummaryPanelWidth() {
+		return summaryPanelWidth;
+	}
+
+	public void setSummaryPanelWidth(int summaryPanelWidth) {
+		this.summaryPanelWidth = summaryPanelWidth;
+	}
+
+	public int getDetailPanelWidth() {
+		return detailPanelWidth;
+	}
+
+	public void setDetailPanelWidth(int detailPanelWidth) {
+		this.detailPanelWidth = detailPanelWidth;
+	}
+
+	public int getPanelHeight() {
+		return panelHeight;
+	}
+
+	public void setPanelHeight(int panelHeight) {
+		this.panelHeight = panelHeight;
+	}
+
+	public int getSummaryLines() {
+		return summaryLines;
+	}
+
+	public void setSummaryLines(int summaryLines) {
+		this.summaryLines = summaryLines;
+	}
+
+	@Override
+	public void loadFromJson(JSONObject storedSettings) {
+		searchMode = storedSettings.optEnum(SearchMode.class, "searchMode", searchMode);
+		caseSensitive = storedSettings.optBoolean("caseSensitive", caseSensitive);
+		if (storedSettings.has("highlightColor")) {
+			highlightColor = ColorFactory.web(storedSettings.getString("highlightColor"));
+		}
+		summaryPanelWidth = storedSettings.optInt("summaryPanelWidth", summaryPanelWidth);
+		detailPanelWidth = storedSettings.optInt("detailPanelWidth", detailPanelWidth);
+		panelHeight = storedSettings.optInt("panelHeight", panelHeight);
+		summaryLines = storedSettings.optInt("summaryLines", summaryLines);
+	}
+
+	@Override
+	public JSONObject storeToJson() {
+		JSONObject result = new JSONObject();
+		result.put("searchMode", searchMode);
+		result.put("caseSensitive", caseSensitive);
+		result.put("highlightColor", ColorFactory.toWebString(highlightColor));
+		result.put("summaryPanelWidth", summaryPanelWidth);
+		result.put("detailPanelWidth", detailPanelWidth);
+		result.put("panelHeight", panelHeight);
+		result.put("summaryLines", summaryLines);
+		return result;
+	}
+}

--- a/src/ui/settings/SettingsManager.java
+++ b/src/ui/settings/SettingsManager.java
@@ -1,0 +1,77 @@
+package ui.settings;
+
+import aya.AyaPrefs;
+import aya.StaticData;
+import aya.util.FileUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.json.JSONObject;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.StandardOpenOption;
+
+public class SettingsManager {
+	private static final String uiSettingsFileName = "ui-settings.json";
+
+	/**
+	 * The File in which ui-settings are stored. Do not access directly, use {@link #getSettingsFile()} instead.
+	 */
+	private static File _uiSettingsFile;
+	private static UiSettings _uiSettings;
+
+	private static File getSettingsFile() {
+		if (_uiSettingsFile == null) {
+			String xdgConfigHome = System.getenv("XDG_CONFIG_HOME");
+			if (StringUtils.isNotBlank(xdgConfigHome)) {
+				File settingsDirectory = new File(xdgConfigHome, "aya");
+				if (!settingsDirectory.isDirectory() && !settingsDirectory.mkdir()) {
+					throw new RuntimeException("The settings directory does not exist and could not be created. (" + settingsDirectory.getAbsolutePath() + ")");
+				}
+				_uiSettingsFile = new File(settingsDirectory, uiSettingsFileName);
+			} else {
+				_uiSettingsFile = new File(AyaPrefs.getAyaRootDirectory(), uiSettingsFileName);
+			}
+		}
+		return _uiSettingsFile;
+	}
+
+	public static UiSettings getUiSettings() {
+		if (_uiSettings == null) {
+			_uiSettings = loadUiSettings();
+		}
+		return _uiSettings;
+	}
+
+	public static void saveUiSettings() {
+		File settingsFile = getSettingsFile();
+		JSONObject settingsObj = getUiSettings().storeToJson();
+		String settingsStr = settingsObj.toString(4);
+		try {
+			StaticData.FILESYSTEM.write(settingsFile, settingsStr.getBytes(StandardCharsets.UTF_8), StandardOpenOption.CREATE, StandardOpenOption.TRUNCATE_EXISTING);
+		} catch (IOException e) {
+			throw new RuntimeException("Unable to store settings to file. (" + settingsFile.getAbsolutePath() + ")", e);
+		}
+	}
+
+	private static UiSettings loadUiSettings() {
+		File settingsFile = getSettingsFile();
+		if (!settingsFile.isFile()) {
+			// no settings saved yet, load defaults
+			return new UiSettings();
+		}
+
+		try {
+			JSONObject settingsObj = new JSONObject(FileUtils.readAllText(settingsFile));
+			int storedVersion = settingsObj.getInt("version");
+			if (storedVersion < UiSettings.latestVersion) {
+				// apply migrations to the settingsObj as needed
+			}
+			UiSettings result = new UiSettings();
+			result.loadFromJson(settingsObj);
+			return result;
+		} catch (IOException e) {
+			throw new RuntimeException("Unable to read settings file. (" + settingsFile.getAbsolutePath() + ")", e);
+		}
+	}
+}

--- a/src/ui/settings/UiSettings.java
+++ b/src/ui/settings/UiSettings.java
@@ -1,0 +1,47 @@
+package ui.settings;
+
+import org.json.JSONObject;
+
+/**
+ * The primary settings Object that contains/references all settings.
+ */
+public class UiSettings implements ISettings {
+	public static final int latestVersion = 0;
+
+	/**
+	 * A monotonically increasing number used to apply automatic migrations of old settings-files.
+	 */
+	private int version = latestVersion;
+
+	private QuickSearchSettings quickSearch = new QuickSearchSettings();
+
+	public int getVersion() {
+		return version;
+	}
+
+	public void setVersion(int version) {
+		this.version = version;
+	}
+
+	public QuickSearchSettings getQuickSearch() {
+		return quickSearch;
+	}
+
+	public void setQuickSearch(QuickSearchSettings quickSearch) {
+		this.quickSearch = quickSearch;
+	}
+
+	@Override
+	public void loadFromJson(JSONObject storedSettings) {
+		version = storedSettings.getInt("version");
+		quickSearch.loadFromJson(storedSettings.getJSONObject("quickSearch"));
+	}
+
+	@Override
+	public JSONObject storeToJson() {
+		JSONObject result = new JSONObject();
+		result.put("version", version);
+		result.put("quickSearch", quickSearch.storeToJson());
+		return result;
+	}
+}


### PR DESCRIPTION
First the parts that I expect to be controversial:
- I've pulled in `org.apache.commons.commons-lang3` for its' case-insensitive `indexOf` Method. Unlike `toLowercase`, this (supposedly) works better for non-ascii characters.
- I have created a config file `ui-settings.json` to store the state of the Quick-Search window (and potentially other UI elements)
  - I'm using `$XDG_CONFIG_HOME/aya/ui-settings.json` if the environment variable is present, otherwise the config is stored in Aya's root directory.

<br/>

## Search Modes
I've extended `StringSearch` to support more search modes, each of these support case-sensitive and case-insensitive searching:
- `Exact` works the same way StringSearch used to work.
- `Regex` uses Regex and sorts by descending match length.
  Some useful example queries are `\bfoo\b` or `foo|bar`.
- `Fuzzy` is an attempt to roughly recreate JetBrains code completion algorithm (see image)
<img width="538" height="76" alt="image" src="https://github.com/user-attachments/assets/5e1b9ab7-552f-4a20-b72a-f963d87b1a4b" />


<br/>

## Quick Search overhaul

<img width="705" height="489" alt="image" src="https://github.com/user-attachments/assets/b2f624ac-016f-4592-a064-d725f466702f" />

- The Quick Search now shows what parts of the string were matched. i.e. to anwser "why is this entry showing up??"
- I have split the window into 'summary' (left) and 'details' (right).
  - By default, the summary shows the first line, the amount of lines are configurable.
  - You can select what's shown in the details panel using ArrowUp/Down or by left-clicking on a summary item.
- To replicate the old behaviour, you can set 'Summary Lines = 0' and `Show Details Panel = false`
- The width/height of each panel is saved to the config file.
- The highlight color can be changed (only by editing the config file)

<br/>

## Config File overview

Example file:
```json
{
    "quickSearch": {
        "highlightColor": "#ffff0040",
        "summaryPanelWidth": 598,
        "detailPanelWidth": 599,
        "panelHeight": 482,
        "showDetailsPanel": true,
        "caseSensitive": true,
        "summaryLines": 1,
        "searchMode": "Exact"
    },
    "version": 0
}
```

|Field|Description|
|---|---|
|`version`|For future use to automatically migrate outdated config files|
|`highlightColor`|Color using Web-Notation for marking text / selected summary boxes, supports alpha|
|`summaryLines`|Number of lines to show in the summary panel, [0, 99], where 0 indicates "unlimited"|

<br/>

## Future potential changes (="TODO")

It might be nice to make the search-modes available here as well:
- https://github.com/aya-lang/aya/blob/09be882c600472df957a124de5ddc19e0bce3ea4/src/aya/instruction/op/MiscOps.java#L262
- https://github.com/aya-lang/aya/blob/09be882c600472df957a124de5ddc19e0bce3ea4/src/aya/InteractiveAya.java#L105