### PR TITLE
Unicode surrogate fix2

### DIFF
--- a/manual/variables_and_scope.md
+++ b/manual/variables_and_scope.md
@@ -11,6 +11,24 @@ aya> 3:b a +
 4
 ```
 
+For single-character variables, you may also use Unicode characters, these identify variables based on their UTF-16 code-units.  
+Single-character variables do not need to be separated by spaces.  
+Characters whose code-points are in range `[0x0, 0xffff]` are encoded using a single code-unit and refer to their literal character.  
+Those in range `[0x10000, 0x10ffff]` are encoded using two code-units refer to pairs of variables.
+
+These pairs of code-units are called "surrogate pairs", they split the Unicode code-point into 10 bits each.  
+Consequently, code-points in range `[0x0, 0x3ff]` can be referred to by these pairs.
+
+```
+aya> 1 2 :á; :ḃ; áḃ
+2 1
+aya> 3:c; 4:d;
+aya> 𨱤 .# '𨱤' encodes 'c' in the first pair, and 'd' in the second.
+3 4
+aya> 𨱤񈑤 .# '񈑤' encodes 'á' in the first pair, and 'd' in the second.
+3 4 2 4
+```
+
 ## Variable Scope
 
 A new scope is introduced if a block contains any variable declaration in its header. When a variable assignment occurs, the interpreter will walk outward until a reference to that variable appears. If it does not appear in any of the scopes before the global scope, a new reference will be created there. In order to ensure a variable is using local scope, the variable name must be included in the block header. If a block does not contain a header, a new scope will not be introduced. These concepts are best demonstrated by example.

--- a/src/aya/StaticData.java
+++ b/src/aya/StaticData.java
@@ -27,6 +27,7 @@ import aya.ext.plot.PlotInstructionStore;
 import aya.ext.socket.SocketInstructionStore;
 import aya.ext.sys.SystemInstructionStore;
 import aya.ext.thread.ThreadInstructionStore;
+import aya.ext.unicode.UnicodeInstructionStore;
 import aya.instruction.named.NamedInstructionStore;
 import aya.instruction.named.NamedOperator;
 import aya.instruction.op.ColonOps;
@@ -159,6 +160,7 @@ public class StaticData {
 		addNamedInstructionStore(new ThreadInstructionStore());
 		addNamedInstructionStore(new LibraryInstructionStore());
 		addNamedInstructionStore(new DownloadInstructionStore());
+		addNamedInstructionStore(new UnicodeInstructionStore());
 	}
 	
 	public ArrayList<NamedInstructionStore> loadLibrary(File path) { 

--- a/src/aya/eval/BlockEvaluator.java
+++ b/src/aya/eval/BlockEvaluator.java
@@ -76,6 +76,17 @@ public class BlockEvaluator {
 	public Obj peek() {
 		return stack.peek();
 	}
+
+	/**
+	 * Peeks into the output stack
+	 * @param depth index into the stack, starting at 0
+	 */
+	public Obj peek(int depth) {
+		int idx = stack.size() - (depth + 1);
+		if (idx < 0 || idx >= stack.size())
+			throw new EmptyStackError("Unexpected empty stack (expected depth of at least " + (depth + 1) + ")");
+		return stack.get(idx);
+	}
 	
 	/** Pops the next instruction from the instruction list */
 	public Instruction next() {

--- a/src/aya/ext/unicode/FromCodePointsInstruction.java
+++ b/src/aya/ext/unicode/FromCodePointsInstruction.java
@@ -1,0 +1,37 @@
+package aya.ext.unicode;
+
+import aya.eval.BlockEvaluator;
+import aya.exceptions.runtime.TypeError;
+import aya.instruction.named.NamedOperator;
+import aya.obj.Obj;
+import aya.obj.list.List;
+import aya.obj.list.numberlist.DoubleList;
+import aya.obj.list.numberlist.NumberList;
+import aya.util.Casting;
+import aya.util.UTF16;
+
+public class FromCodePointsInstruction extends NamedOperator {
+	public FromCodePointsInstruction() {
+		super("unicode.from_code_points");
+		_doc = "(L|N) convert code-point(s) to unicode string";
+	}
+
+	@Override
+	public void execute(BlockEvaluator blockEvaluator) {
+		Obj l = blockEvaluator.pop();
+		final NumberList codePoints;
+		if (l.isa(Obj.NUMBERLIST)) {
+			codePoints = Casting.asNumberList(l);
+		}else if(l.isa(Obj.NUMBER)) {
+			codePoints = new DoubleList(Casting.asNumber(l).toDouble(), 1);
+		}else{
+			throw new TypeError(this, "L|N", l);
+		}
+
+		StringBuilder s = new StringBuilder();
+		for (int i = 0; i < codePoints.length(); i++) {
+			UTF16.codePointToStr(codePoints.get(i).toInt(), s);
+		}
+		blockEvaluator.push(List.fromString(s.toString()));
+	}
+}

--- a/src/aya/ext/unicode/ToCodePointsInstruction.java
+++ b/src/aya/ext/unicode/ToCodePointsInstruction.java
@@ -1,0 +1,44 @@
+package aya.ext.unicode;
+
+import aya.eval.BlockEvaluator;
+import aya.exceptions.runtime.TypeError;
+import aya.instruction.named.NamedOperator;
+import aya.obj.Obj;
+import aya.obj.list.List;
+import aya.obj.list.numberlist.DoubleList;
+import aya.util.UTF16;
+
+public class ToCodePointsInstruction extends NamedOperator {
+	public ToCodePointsInstruction() {
+		super("unicode.to_code_points");
+		_doc = "(S) convert string to unicode code-points (list of numbers)";
+	}
+
+	@Override
+	public void execute(BlockEvaluator blockEvaluator) {
+		Obj s = blockEvaluator.pop();
+		if (!s.isa(Obj.STR)) {
+			throw new TypeError(this, "S", s);
+		}
+
+		char[] chars = s.str().toCharArray();
+		double[] codePoints = new double[chars.length]; // upper bound
+		int cpOffset = 0;
+		for (int i = 0; i < chars.length; i++, cpOffset++) {
+			if (UTF16.isHighSurrogate(chars[i]) && (i + 1) < chars.length) {
+				codePoints[cpOffset] = Character.toCodePoint(chars[i], chars[i + 1]);
+				i++;
+			} else {
+				codePoints[cpOffset] = chars[i] & 0xffff;
+			}
+		}
+
+		if (cpOffset < codePoints.length) {
+			double[] trimmedCodePoints = new double[cpOffset];
+			System.arraycopy(codePoints, 0, trimmedCodePoints, 0, cpOffset);
+			codePoints = trimmedCodePoints;
+		}
+
+		blockEvaluator.push(new List(new DoubleList(codePoints)));
+	}
+}

--- a/src/aya/ext/unicode/UTF16FromCodeUnitsInstruction.java
+++ b/src/aya/ext/unicode/UTF16FromCodeUnitsInstruction.java
@@ -13,7 +13,7 @@ public class UTF16FromCodeUnitsInstruction extends NamedOperator {
 
 	public UTF16FromCodeUnitsInstruction() {
 		super("utf16.from_code_units");
-		_doc = "(L) convert list of code units (16 bit numbers) to a string using utf-16 encoding";
+		_doc = "(L|N) convert list of code unit(s) (16 bit numbers) to a string using utf-16 encoding";
 	}
 
 	@Override

--- a/src/aya/ext/unicode/UTF16FromCodeUnitsInstruction.java
+++ b/src/aya/ext/unicode/UTF16FromCodeUnitsInstruction.java
@@ -1,0 +1,38 @@
+package aya.ext.unicode;
+
+import aya.eval.BlockEvaluator;
+import aya.exceptions.runtime.TypeError;
+import aya.instruction.named.NamedOperator;
+import aya.obj.Obj;
+import aya.obj.list.List;
+import aya.obj.list.numberlist.DoubleList;
+import aya.obj.list.numberlist.NumberList;
+import aya.util.Casting;
+
+public class UTF16FromCodeUnitsInstruction extends NamedOperator {
+
+	public UTF16FromCodeUnitsInstruction() {
+		super("utf16.from_code_units");
+		_doc = "(L) convert list of code units (16 bit numbers) to a string using utf-16 encoding";
+	}
+
+	@Override
+	public void execute(BlockEvaluator blockEvaluator) {
+		Obj l = blockEvaluator.pop();
+		final NumberList codeUnits;
+		if (l.isa(Obj.NUMBERLIST)) {
+			codeUnits = Casting.asNumberList(l);
+		} else if (l.isa(Obj.NUMBER)) {
+			codeUnits = new DoubleList(Casting.asNumber(l).toDouble(), 1);
+		} else {
+			throw new TypeError(this, "L|N", l);
+		}
+
+		char[] chars = new char[codeUnits.length()];
+		for (int i = 0; i < codeUnits.length(); i++) {
+			int codeUnit = codeUnits.get(i).toInt() & 0xffff;
+			chars[i] = (char) codeUnit; // this works without extra effort because Java uses UTF-16 internally
+		}
+		blockEvaluator.push(List.fromString(new String(chars)));
+	}
+}

--- a/src/aya/ext/unicode/UTF16FromTuplesInstruction.java
+++ b/src/aya/ext/unicode/UTF16FromTuplesInstruction.java
@@ -1,0 +1,60 @@
+package aya.ext.unicode;
+
+import aya.eval.BlockEvaluator;
+import aya.exceptions.runtime.TypeError;
+import aya.instruction.named.NamedOperator;
+import aya.obj.Obj;
+import aya.obj.list.List;
+import aya.util.Casting;
+import aya.util.UTF16;
+
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+
+public class UTF16FromTuplesInstruction extends NamedOperator {
+
+	public UTF16FromTuplesInstruction() {
+		super("utf16.from_tuples");
+		_doc = "(S|L<S>) unpack a list of tuple-strings to their corresponding variables using utf16 surrogate pairs (return L<S>)";
+	}
+
+	@Override
+	public void execute(BlockEvaluator blockEvaluator) {
+		Obj l = blockEvaluator.pop();
+		final List tuples;
+		if (l.isa(Obj.STR)) {
+			ArrayList<Obj> strList = new ArrayList<>();
+			strList.add(List.fromStr(Casting.asStr(l)));
+			tuples = new List(strList);
+		} else if (l.isa(Obj.LIST)) {
+			tuples = Casting.asList(l);
+		} else {
+			throw new TypeError(this, "S|L", l);
+		}
+
+		ArrayList<Obj> result = IntStream.range(0, tuples.length())
+				.mapToObj(i -> {
+					Obj symbol = tuples.getExact(i);
+					if (symbol.isa(Obj.STR)) {
+						return Casting.asStr(symbol).str();
+					} else {
+						throw new TypeError("TypeError at " + this._name + " l.[" + i + "]. Expected S, found " + symbol.repr());
+					}
+				})
+				.flatMap(tuple -> {
+					if (tuple.length() == 2 && UTF16.isHighSurrogate(tuple.charAt(0))) {
+						String highSurrogate = "" + ((char) (tuple.charAt(0) & 0b11_1111_1111));
+						String lowSurrogate = "" + ((char) (tuple.charAt(1) & 0b11_1111_1111));
+						return Stream.of(highSurrogate, lowSurrogate);
+					} else {
+						return Stream.of(tuple);
+					}
+				})
+				.map(List::fromString)
+				.collect(Collectors.toCollection(ArrayList::new));
+
+		blockEvaluator.push(new List(result));
+	}
+}

--- a/src/aya/ext/unicode/UTF16ToCodeUnitsInstruction.java
+++ b/src/aya/ext/unicode/UTF16ToCodeUnitsInstruction.java
@@ -1,0 +1,30 @@
+package aya.ext.unicode;
+
+import aya.eval.BlockEvaluator;
+import aya.exceptions.runtime.TypeError;
+import aya.instruction.named.NamedOperator;
+import aya.obj.Obj;
+import aya.obj.list.List;
+import aya.obj.list.numberlist.DoubleList;
+
+public class UTF16ToCodeUnitsInstruction extends NamedOperator {
+	public UTF16ToCodeUnitsInstruction() {
+		super("utf16.to_code_units");
+		_doc = "(S) convert string to list of code units (16 bit numbers) using utf-16 encoding";
+	}
+
+	@Override
+	public void execute(BlockEvaluator blockEvaluator) {
+		Obj s = blockEvaluator.pop();
+		if (!s.isa(Obj.STR)) {
+			throw new TypeError(this, "S", s);
+		}
+
+		char[] chars = s.str().toCharArray();
+		double[] codeUnits = new double[chars.length];
+		for (int i = 0; i < chars.length; i++) {
+			codeUnits[i] = chars[i] & 0xffff; // this works without extra effort because Java uses UTF-16 internally
+		}
+		blockEvaluator.push(new List(new DoubleList(codeUnits)));
+	}
+}

--- a/src/aya/ext/unicode/UTF16ToTuplesInstruction.java
+++ b/src/aya/ext/unicode/UTF16ToTuplesInstruction.java
@@ -1,0 +1,85 @@
+package aya.ext.unicode;
+
+import aya.eval.BlockEvaluator;
+import aya.exceptions.runtime.TypeError;
+import aya.instruction.named.NamedOperator;
+import aya.obj.Obj;
+import aya.obj.list.List;
+import aya.util.Casting;
+import aya.util.UTF16;
+
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+public class UTF16ToTuplesInstruction extends NamedOperator {
+
+	public UTF16ToTuplesInstruction() {
+		super("utf16.to_tuples");
+		_doc = "(L<J>|L<S>|L<C>) convert a list of symbols/strings/chars into 2-tuples using utf16 surrogate pairs (return L<S>)";
+	}
+
+	@Override
+	public void execute(BlockEvaluator blockEvaluator) {
+		Obj l = blockEvaluator.pop();
+		final List symbols;
+		if (l.isa(Obj.LIST)) {
+			symbols = Casting.asList(l);
+		} else {
+			throw new TypeError(this, "L", l);
+		}
+
+		ArrayList<String> symbolStrings = IntStream.range(0, symbols.length())
+				.mapToObj(i -> {
+					Obj symbol = symbols.getExact(i);
+					if (symbol.isa(Obj.SYMBOL)) {
+						return Casting.asSymbol(symbol).name();
+					} else if (symbol.isa(Obj.STR)) {
+						return Casting.asStr(symbol).str();
+					} else if (symbol.isa(Obj.CHAR)) {
+						return Casting.asChar(symbol).str();
+					} else {
+						throw new TypeError("TypeError at " + this._name + " l.[" + i + "]. Expected S|J|C, found " + symbol.repr());
+					}
+				}).collect(Collectors.toCollection(ArrayList::new));
+
+		ArrayList<String> result = new ArrayList<>();
+		for (int i = 0; i < symbolStrings.size(); i++) {
+			String symbolStr1 = symbolStrings.get(i);
+			if (viableSurrogateChar(symbolStr1) && (i + 1) < symbolStrings.size()) {
+				// maybe this and the next symbol can be combined into a tuple
+				i++;
+				String symbolStr2 = symbolStrings.get(i);
+				if (viableSurrogateChar(symbolStr2)) {
+					result.add(UTF16.surrogateToStr(
+							((UTF16.highSurrogateBase | (symbolStr1.charAt(0) & 0b11_1111_1111)) << 16)
+									| (UTF16.lowSurrogateBase | (symbolStr2.charAt(0) & 0b11_1111_1111))
+					));
+				} else {
+					result.add(symbolStr1);
+					result.add(symbolStr2);
+				}
+			} else {
+				// too long/short to be combined with another character
+				result.add(symbolStr1);
+			}
+		}
+
+		ArrayList<Obj> strList = result.stream().map(List::fromString).collect(Collectors.toCollection(ArrayList::new));
+		blockEvaluator.push(new List(strList));
+	}
+
+	private static boolean viableSurrogateChar(String symbol) {
+		if (symbol.length() != 1)
+			return false; // too long/short to be combined with another character
+
+		int c = symbol.charAt(0) & 0xffff;
+		if (UTF16.isSurrogate(c))
+			return false; // already a surrogate (this *should* be impossible since these characters are forbidden by the Unicode standard)
+
+		if ((c & 0b1111_1100_0000_0000) != 0)
+			return false; // cannot be represented with only 10 bits
+
+		return true;
+	}
+}

--- a/src/aya/ext/unicode/UnicodeInstructionStore.java
+++ b/src/aya/ext/unicode/UnicodeInstructionStore.java
@@ -14,7 +14,9 @@ public class UnicodeInstructionStore implements NamedInstructionStore {
 				new FromCodePointsInstruction(),
 				new ToCodePointsInstruction(),
 				new UTF16FromCodeUnitsInstruction(),
-				new UTF16ToCodeUnitsInstruction()
+				new UTF16ToCodeUnitsInstruction(),
+				new UTF16ToTuplesInstruction(),
+				new UTF16FromTuplesInstruction()
 		);
 	}
 }

--- a/src/aya/ext/unicode/UnicodeInstructionStore.java
+++ b/src/aya/ext/unicode/UnicodeInstructionStore.java
@@ -1,0 +1,20 @@
+package aya.ext.unicode;
+
+import aya.instruction.named.NamedInstructionStore;
+import aya.instruction.named.NamedOperator;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+public class UnicodeInstructionStore implements NamedInstructionStore {
+
+	@Override
+	public Collection<NamedOperator> getNamedInstructions() {
+		return Arrays.asList(
+				new FromCodePointsInstruction(),
+				new ToCodePointsInstruction(),
+				new UTF16FromCodeUnitsInstruction(),
+				new UTF16ToCodeUnitsInstruction()
+		);
+	}
+}

--- a/src/aya/instruction/InstructionStack.java
+++ b/src/aya/instruction/InstructionStack.java
@@ -8,7 +8,6 @@ import aya.ReprStream;
 import aya.eval.BlockEvaluator;
 import aya.exceptions.runtime.ValueError;
 import aya.instruction.flag.FlagInstruction;
-import aya.instruction.variable.GetVariableInstruction;
 import aya.obj.Obj;
 import aya.obj.block.BlockHeader;
 import aya.obj.symbol.Symbol;
@@ -137,19 +136,6 @@ public class InstructionStack {
 		}
 	}
 
-	
-	/** Finds all vars with id matching varid and swaps them
-	 * with `item`
-	 */
-	public void assignVarValue(Symbol var, Obj item) {
-		for (int i = 0; i < instructions.size(); i++) {
-			final Instruction o = instructions.get(i);
-			if (o instanceof GetVariableInstruction && ((GetVariableInstruction)o).getSymbol().id() == var.id()) {
-				instructions.set(i, new DataInstruction(item));
-			}
-		}
-	}
-	
 
 	///////////////////////
 	// String Conversion //

--- a/src/aya/instruction/InterpolateStringInstruction.java
+++ b/src/aya/instruction/InterpolateStringInstruction.java
@@ -7,6 +7,7 @@ import aya.exceptions.runtime.UndefVarException;
 import aya.instruction.variable.GetVariableInstruction;
 import aya.obj.Obj;
 import aya.obj.list.List;
+import aya.obj.symbol.Symbol;
 import aya.parser.SourceStringRef;
 import aya.util.Casting;
 
@@ -34,7 +35,9 @@ public class InterpolateStringInstruction extends Instruction  {
 			if (current instanceof GetVariableInstruction) {
 				GetVariableInstruction var = (GetVariableInstruction)current;
 				try {
-					sb.append(context.getVars().getVar(var.getSymbol()).str());
+					for (Symbol symbol : var.getSymbols()) {
+						sb.append(context.getVars().getVar(symbol).str());
+					}
 				} catch (UndefVarException e) {
 					e.setSource(var.getSource());
 					throw e;

--- a/src/aya/instruction/op/Ops.java
+++ b/src/aya/instruction/op/Ops.java
@@ -66,6 +66,7 @@ import aya.parser.SourceStringRef;
 import aya.util.Casting;
 import aya.util.FileUtils;
 import aya.util.Pair;
+import aya.util.UTF16;
 import aya.util.VectorizedFunctions;
 
 public class Ops {
@@ -168,7 +169,11 @@ public class Ops {
 		}
 		return false;
 	}
-	
+
+	public static boolean isOpChar(int c) {
+		return UTF16.is2Byte(c) && isOpChar((char) c);
+	}
+
 	public static boolean isOpChar(char c) {
 		char[] op_exceptions = {
 				',','(',')','[',']','`','.','"','\'', '#','_'

--- a/src/aya/instruction/variable/GetCDictInstruction.java
+++ b/src/aya/instruction/variable/GetCDictInstruction.java
@@ -27,7 +27,7 @@ public class GetCDictInstruction extends VariableInstruction {
 	
 	@Override
 	public ReprStream repr(ReprStream stream) {
-		stream.print(Parser.CDICT_CHAR + variable_.name());
+		stream.print(Parser.CDICT_CHAR + varName_);
 		return stream;
 	}
 	

--- a/src/aya/instruction/variable/GetKeyVariableInstruction.java
+++ b/src/aya/instruction/variable/GetKeyVariableInstruction.java
@@ -22,23 +22,25 @@ public class GetKeyVariableInstruction extends GetVariableInstruction {
 		if (kv_obj.isa(Obj.DICT)) {
 			Dict dict;
 			dict = (Dict)kv_obj;
-			Obj o = dict.get(variable_);
+			for (Symbol variable : variables_) {
+				Obj o = dict.get(variable);
 
-			if (o.isa(Obj.BLOCK)) {
-				// If user object function, leave it as the first item on the stack
-				if (dict.pushSelf()) b.push(dict);
-				dumpBlock(Casting.asStaticBlock(o), b);
-			} else {
-				b.push(o);
+				if (o.isa(Obj.BLOCK)) {
+					// If user object function, leave it as the first item on the stack
+					if (dict.pushSelf()) b.push(dict);
+					dumpBlock(Casting.asStaticBlock(o), b);
+				} else {
+					b.push(o);
+				}
 			}
 		} else {
 			Dict builtin_dict = b.getContext().getVars().getBuiltinMeta(kv_obj);
-			Dict dict = (Dict)builtin_dict;
-			Obj o;
 			try {
-				o = dict.get(variable_);
-				if (variable_ != SymbolConstants.KEYVAR_META) b.push(kv_obj); // Don't push if we are accessing the meta dict
-				this.addOrDumpVar(o, b);
+				for (Symbol variable : variables_) {
+					Obj o = builtin_dict.get(variable);
+					if (variable != SymbolConstants.KEYVAR_META) b.push(kv_obj); // Don't push if we are accessing the meta dict
+					this.addOrDumpVar(o, b);
+				}
 			} catch (IndexError e) {
 				throw new IndexError("Built in type " + Obj.IDToSym(kv_obj.type()) + 
 						" does not contain member '" + varName() + "'");
@@ -49,7 +51,7 @@ public class GetKeyVariableInstruction extends GetVariableInstruction {
 	
 	@Override
 	public ReprStream repr(ReprStream stream) {
-		stream.print("." + variable_.name());
+		stream.print("." + varName_);
 		return stream;
 	}
 	

--- a/src/aya/instruction/variable/GetVariableInstruction.java
+++ b/src/aya/instruction/variable/GetVariableInstruction.java
@@ -17,8 +17,10 @@ public class GetVariableInstruction extends VariableInstruction {
 	
 	@Override
 	public void execute(BlockEvaluator b) {
-		Obj o = b.getContext().getVars().getVar(variable_);
-		this.addOrDumpVar(o, b);
+		for (Symbol variable : variables_) {
+			Obj o = b.getContext().getVars().getVar(variable);
+			this.addOrDumpVar(o, b);
+		}
 	}
 	
 	/**
@@ -43,7 +45,7 @@ public class GetVariableInstruction extends VariableInstruction {
 
 	@Override
 	public ReprStream repr(ReprStream stream) {
-		stream.print(variable_.name());
+		stream.print(varName_);
 		return stream;
 	}
 }

--- a/src/aya/instruction/variable/QuoteGetKeyVariableInstruction.java
+++ b/src/aya/instruction/variable/QuoteGetKeyVariableInstruction.java
@@ -20,18 +20,21 @@ public class QuoteGetKeyVariableInstruction extends VariableInstruction {
 		if (kv_obj.isa(Obj.DICT)) {
 			Dict dict;
 			dict = (Dict)kv_obj;
-			Obj o = dict.get(variable_);
-			b.push(o);
+			for (Symbol variable : variables_) {
+				Obj o = dict.get(variable);
+				b.push(o);
+			}
 		} else {
 			Symbol typeSym = Obj.IDToSym(kv_obj.type());
 			Obj builtin_dict = b.getContext().getVars().getGlobals().get(typeSym);
 			if (builtin_dict.isa(Obj.DICT)) {
 				Dict dict = (Dict)builtin_dict;
-				Obj o;
 				try {
-					o = dict.get(variable_);
-					//b.push(kv_obj);
-					b.push(o);
+					for (Symbol variable : variables_) {
+						Obj o = dict.get(variable);
+						//b.push(kv_obj);
+						b.push(o);
+					}
 				} catch (IndexError e) {
 					throw new IndexError("Built in type " + typeSym + 
 							" does not contain member '" + varName() + "'");
@@ -45,7 +48,7 @@ public class QuoteGetKeyVariableInstruction extends VariableInstruction {
 
 	@Override
 	public ReprStream repr(ReprStream stream) {
-		stream.print("." + variable_.name() + ".`");
+		stream.print("." + varName_ + ".`");
 		return stream;
 	}
 }

--- a/src/aya/instruction/variable/QuoteGetVariableInstruction.java
+++ b/src/aya/instruction/variable/QuoteGetVariableInstruction.java
@@ -15,8 +15,10 @@ public class QuoteGetVariableInstruction extends VariableInstruction {
 	
 	@Override
 	public void execute(BlockEvaluator b) {
-		Obj o = b.getContext().getVars().getVar(variable_);
-		b.push(o);
+		for (Symbol variable : variables_) {
+			Obj o = b.getContext().getVars().getVar(variable);
+			b.push(o);
+		}
 	}
 	
 	/**
@@ -35,7 +37,7 @@ public class QuoteGetVariableInstruction extends VariableInstruction {
 	
 	@Override
 	public ReprStream repr(ReprStream stream) {
-		stream.print(variable_.name() + ".`");
+		stream.print(varName_ + ".`");
 		return stream;
 	}
 }

--- a/src/aya/instruction/variable/SetKeyVariableInstruction.java
+++ b/src/aya/instruction/variable/SetKeyVariableInstruction.java
@@ -19,14 +19,16 @@ public class SetKeyVariableInstruction extends VariableInstruction {
 		if (kv_obj.isa(Obj.DICT)) {
 			Dict dict;
 			dict = (Dict)kv_obj;
-			dict.set(variable_, b.pop());
+			for (int i = variables_.length - 1; i >= 0; i--) {
+				dict.set(variables_[i], b.pop());
+			}
 			b.push(dict);
 		}
 	}
 	
 	@Override
 	public ReprStream repr(ReprStream stream) {
-		stream.print(".:" + variable_.name());
+		stream.print(".:" + varName_);
 		return stream;
 	}
 }

--- a/src/aya/instruction/variable/SetVariableInstruction.java
+++ b/src/aya/instruction/variable/SetVariableInstruction.java
@@ -6,19 +6,22 @@ import aya.obj.symbol.Symbol;
 import aya.parser.SourceStringRef;
 
 public class SetVariableInstruction extends VariableInstruction {
-	
+
 	public SetVariableInstruction(SourceStringRef source, Symbol var) {
 		super(source, var);
 	}
-	
+
 	@Override
 	public void execute(BlockEvaluator b) {
-		b.getContext().getVars().setVar(variable_, b.peek());
+		int numVars = variables_.length;
+		for (int i = 0; i < numVars; i++) {
+			b.getContext().getVars().setVar(variables_[i], b.peek(numVars - (i + 1)));
+		}
 	}
-	
+
 	@Override
 	public ReprStream repr(ReprStream stream) {
-		stream.print(":" + variable_.name());
+		stream.print(":" + varName_);
 		return stream;
 	}
 }

--- a/src/aya/instruction/variable/VariableInstruction.java
+++ b/src/aya/instruction/variable/VariableInstruction.java
@@ -2,23 +2,47 @@ package aya.instruction.variable;
 
 import aya.instruction.Instruction;
 import aya.obj.symbol.Symbol;
+import aya.obj.symbol.SymbolTable;
 import aya.parser.SourceStringRef;
+import aya.util.UTF16;
 
 public abstract class VariableInstruction extends Instruction {
 
-	protected Symbol variable_;
-	
+	protected final String varName_;
+	protected final Symbol originalVar_;
+	protected final Symbol[] variables_;
+
 	protected VariableInstruction(SourceStringRef source, Symbol var) {
 		super(source);
-		variable_ = var;
+		originalVar_ = var;
+		varName_ = var.name();
+		if (varName_.length() == 2 && UTF16.isHighSurrogate(varName_.charAt(0))) {
+			// surrogate pair
+			String highSurrogate = "" + ((char) (varName_.charAt(0) & 0b11_1111_1111)); // ignore the leading 6 bits (surrogate identifier)
+			String lowSurrogate = "" + ((char) (varName_.charAt(1) & 0b11_1111_1111));
+			variables_ = new Symbol[]{SymbolTable.getSymbol(highSurrogate), SymbolTable.getSymbol(lowSurrogate)};
+		} else {
+			// regular variable name
+			variables_ = new Symbol[]{var};
+		}
 	}
-	
+
 	public String varName() {
-		return variable_.name();
+		return varName_;
 	}
-	
-	public Symbol getSymbol() {
-		return variable_;
+
+	/**
+	 * @return the initial variable, before it was reinterpreted into tuples.
+	 */
+	public Symbol getOriginalVar() {
+		return originalVar_;
+	}
+
+	/**
+	 * @return the variables of this tuple
+	 */
+	public Symbol[] getSymbols() {
+		return variables_;
 	}
 
 }

--- a/src/aya/obj/symbol/SymbolTable.java
+++ b/src/aya/obj/symbol/SymbolTable.java
@@ -1,5 +1,7 @@
 package aya.obj.symbol;
 
+import aya.util.UTF16;
+
 import java.util.HashMap;
 
 public class SymbolTable {
@@ -37,6 +39,11 @@ public class SymbolTable {
 	/** Returns true if the string contains only lowercase alpha and underscores */
 	public static boolean isBasicSymbolString(String name) {
 		return isValidStr(name);
+	}
+
+	/** Returns true if the string contains only lowercase alpha and underscores */
+	public static boolean isBasicSymbolChar(int c) {
+		return UTF16.is2Byte(c) && isValidChar((char) c);
 	}
 
 	/** Returns true if the string contains only lowercase alpha and underscores */

--- a/src/aya/parser/ParserString.java
+++ b/src/aya/parser/ParserString.java
@@ -1,6 +1,7 @@
 package aya.parser;
 
 import aya.exceptions.parser.EndOfInputError;
+import aya.util.UTF16;
 
 public class ParserString {
 	private SourceString source;
@@ -8,7 +9,7 @@ public class ParserString {
 	private int ix;
 	private int end_ix;
 	private int start_ix;
-	
+
 	public ParserString(SourceString source) {
 		this(source, 0, source.length());
 	}
@@ -43,22 +44,32 @@ public class ParserString {
 		this.start_ix = offset;
 		this.end_ix = offset + length;
 	}
-	
+
 	/** "Removes" and returns the first character in the string */
-	public char next() throws EndOfInputError {
-		if(ix >= this.end_ix) {
+	public int next() throws EndOfInputError {
+		if (ix >= this.end_ix) {
 			throw new EndOfInputError("Unexpected End of Input", currentRef());
 		}
-		char c = chars[ix];
+		int c = chars[ix] & 0xffff; // bitmask to avoid problems during the widening conversion of negative values
 		ix++;
+
+		if (UTF16.isHighSurrogate(c) && ix < this.end_ix) {
+			c <<= 16;
+			c |= (chars[ix] & 0xffff);
+			ix++;
+		}
 		return c;
 	}
-	
+
+	public String nextStr() throws EndOfInputError {
+		return UTF16.surrogateToStr(next());
+	}
+
 	/** Returns the first character in the string */
 	public char peek() {
 		return chars[ix];
 	}
-	
+
 	/** Returns the nth next character in the string. peek() == peek(0) */
 	public char peek(int i) {
 		return chars[ix + i];
@@ -69,17 +80,17 @@ public class ParserString {
 		ix--;
 		if (ix < 0) ix = 0;
 	}
-	
+
 	/** Returns false if there is no more data to be parsed by looking ahead i characters. hasNext() == hasNext(0) */
 	public boolean hasNext(int i) {
 		return (ix + i) < this.end_ix;
 	}
-	
+
 	/** Returns true if there is no more data to be parsed */
 	public boolean isEmpty() {
 		return ix >= this.end_ix;
 	}
-	
+
 	/** Returns false if there is no more data to be parsed (opposite of isEmpty)*/
 	public boolean hasNext() {
 		return ix < this.end_ix;
@@ -89,15 +100,15 @@ public class ParserString {
 	public String toString() {
 		return new String(this.source.getRawString().substring(this.start_ix, this.end_ix));
 	}
-	
+
 	public SourceString getSource() {
 		return this.source;
 	}
-	
+
 	public int currentIndex() {
 		return this.ix-1;
 	}
-	
+
 	public SourceStringRef currentRef() {
 		return new SourceStringRef(this.source, this.currentIndex());
 	}

--- a/src/aya/parser/StringParseUtils.java
+++ b/src/aya/parser/StringParseUtils.java
@@ -2,21 +2,22 @@ package aya.parser;
 
 import aya.exceptions.parser.EndOfInputError;
 import aya.exceptions.parser.SyntaxError;
+import aya.util.UTF16;
 
 public class StringParseUtils {
 
 	public static String goToEnd(ParserString in, char termination) throws EndOfInputError {
 		StringBuilder out = new StringBuilder();
 		while (in.hasNext()) {
-			char c = in.next();
+			int c = in.next();
 
 			if (c == '\\' && in.hasNext()) {
-				out.append(c);
-				out.append(in.next());
+				out.append(UTF16.surrogateToStr(c));
+				out.append(in.nextStr());
 			} else if (c == termination) {
 				return out.toString();
 			} else {
-				out.append(c);
+				out.append(UTF16.surrogateToStr(c));
 			}
 		}
 		// End of input
@@ -26,9 +27,9 @@ public class StringParseUtils {
 	public static String unescape(ParserString in) throws SyntaxError, EndOfInputError {
 		StringBuilder str = new StringBuilder();
 		while (in.hasNext()) {
-			char c = in.next();
+			int c = in.next();
 			if (c == '\\') {
-				char escape = in.next();
+				int escape = in.next();
 				switch (escape) {
 				case '$':
 					str.append("$");
@@ -69,7 +70,7 @@ public class StringParseUtils {
 							in.next(); // Skip the closing '}'
 							break;
 						}
-						sc.append(in.next());
+						sc.append(in.nextStr());
 					}
 
 					if (!specialComplete) {
@@ -95,10 +96,10 @@ public class StringParseUtils {
 				default:
 					// throw new SyntaxError("'" + escape + "' is not a valid escape character....
 					// Always return a valid result
-					str.append('\\').append(escape);
+					str.append('\\').append(UTF16.surrogateToStr(escape));
 				}
 			} else {
-				str.append(c);
+				str.append(UTF16.surrogateToStr(c));
 			}
 		}
 		return str.toString();

--- a/src/aya/parser/tokens/SpecialToken.java
+++ b/src/aya/parser/tokens/SpecialToken.java
@@ -2,6 +2,7 @@ package aya.parser.tokens;
 
 import aya.instruction.Instruction;
 import aya.parser.SourceStringRef;
+import aya.util.UTF16;
 
 public class SpecialToken extends Token {
 	String name;
@@ -24,6 +25,11 @@ public class SpecialToken extends Token {
 	@Override
 	public Instruction getInstruction() {
 		throw new RuntimeException("Cannot generate aya code for special token");
+	}
+
+	/** Converts a character into a token representation */
+	public static SpecialToken get(int c, SourceStringRef source) {
+		return UTF16.is2Byte(c) ? get((char) c, source) : null;
 	}
 
 	/** Converts a character into a token representation */

--- a/src/aya/parser/tokens/StringToken.java
+++ b/src/aya/parser/tokens/StringToken.java
@@ -14,6 +14,7 @@ import aya.parser.Parser;
 import aya.parser.ParserString;
 import aya.parser.SourceStringRef;
 import aya.parser.StringParseUtils;
+import aya.util.UTF16;
 
 public class StringToken extends StdToken {
 		
@@ -46,7 +47,7 @@ public class StringToken extends StdToken {
 		InstructionStack instrs = new InstructionStack();
 		
 		while(in.hasNext()) {
-			char c = in.next();
+			int c = in.next();
 			
 			//Escaped dollar sign
 			if (c == '\\' && in.hasNext() && in.peek() == '$') {
@@ -60,9 +61,9 @@ public class StringToken extends StdToken {
 				
 				//Normal Var
 				if (SymbolTable.isBasicSymbolChar(c)) {
-					String var_name = ""+c;
+					StringBuilder var_name = new StringBuilder(UTF16.surrogateToStr(c));
 					while (in.hasNext() && SymbolTable.isBasicSymbolChar(in.peek())) {
-						var_name += in.next();
+						var_name.append(in.nextStr());
 					}
 					
 					//Add and reset the string builder
@@ -73,7 +74,7 @@ public class StringToken extends StdToken {
 					sb.setLength(0);
 					
 					//Add the variable
-					instrs.insert(0, new GetVariableInstruction(ref, SymbolTable.getSymbol(var_name)));
+					instrs.insert(0, new GetVariableInstruction(ref, SymbolTable.getSymbol(var_name.toString())));
 					
 				}
 				
@@ -106,7 +107,7 @@ public class StringToken extends StdToken {
 						
 						//Other
 						else {
-							block.append(in.next());
+							block.append(in.nextStr());
 						}
 					}
 					
@@ -131,13 +132,13 @@ public class StringToken extends StdToken {
 				
 				//No Interpolation, just place the chars normally
 				else {
-					sb.append('$').append(c);
+					sb.append('$').append(UTF16.surrogateToStr(c));
 				}
 			} 
 			
 			//Normal char; do nothing
 			else {
-				sb.append(c);
+				sb.append(UTF16.surrogateToStr(c));
 			}
 		}
 		

--- a/src/aya/util/CharUtils.java
+++ b/src/aya/util/CharUtils.java
@@ -4,7 +4,7 @@ public class CharUtils {
 
 	/** Returns a character given its unicode value as a hex string */
 	public static char getCharUni(String unicode) {
-		return (char)Integer.parseInt(unicode, 16);
+		return (char) Integer.parseInt(unicode, 16);
 	}
 
 	/** Returns true if the character is lowercase a-z */
@@ -12,6 +12,11 @@ public class CharUtils {
 		return (c >= 'a' && c <= 'z');
 	}
 
+
+	/** Returns true if the character is 0-9 */
+	public static boolean isDigit(int c) {
+		return UTF16.is2Byte(c) && isDigit((char) c);
+	}
 
 	/** Returns true if the character is 0-9 */
 	public static boolean isDigit(char c) {

--- a/src/aya/util/UTF16.java
+++ b/src/aya/util/UTF16.java
@@ -1,0 +1,79 @@
+package aya.util;
+
+/**
+ * Because {@code sun.text.normalizer.UTF16} is JDK dependent (=sometimes not available) this reimplements the core functionality used by Aya.
+ */
+public class UTF16 {
+	/**
+	 * The leading 6 bits identifying a "high surrogate" code-unit (the upper 10 bits of the encoded code-point)
+	 */
+	public static final int highSurrogateBase = 0xd800;
+	/**
+	 * The leading 6 bits identifying a "low surrogate" code-unit (the lower 10 bits of the encoded code-point)
+	 */
+	public static final int lowSurrogateBase = 0xdc00;
+
+	public static final int surrogateMin = Math.min(highSurrogateBase, lowSurrogateBase);
+	public static final int surrogateMax = Math.max(highSurrogateBase, lowSurrogateBase) + 0x3ff;
+
+	public static boolean isHighSurrogate(int codeUnit) {
+		return (codeUnit & 0b1111_1100_0000_0000) == highSurrogateBase;
+	}
+
+	public static boolean isLowSurrogate(int codeUnit) {
+		return (codeUnit & 0b1111_1100_0000_0000) == lowSurrogateBase;
+	}
+
+	public static boolean isSurrogate(int codeUnit) {
+		return codeUnit >= surrogateMin && codeUnit <= surrogateMax;
+	}
+
+	/**
+	 * @return {@code true} if the given (pseudo-unsigned) 4 byte integer can be safely narrowed to 2 bytes.
+	 */
+	public static boolean is2Byte(int utf16EncodedChar) {
+		return utf16EncodedChar >= 0 && utf16EncodedChar <= 0xffff;
+	}
+
+	/**
+	 * Converts a utf16 encoded character (either a surrogate pair or a BMP character) to a string.
+	 */
+	public static String surrogateToStr(int utf16EncodedChar) {
+		if (is2Byte(utf16EncodedChar)) {
+			return "" + ((char) utf16EncodedChar);
+		} else {
+			return new String(new char[]{
+					((char) (utf16EncodedChar >> 16)),
+					((char) utf16EncodedChar)
+			});
+		}
+	}
+
+	/**
+	 * Converts a Unicode code-point to a string.
+	 */
+	public static String codePointToStr(int codePoint) {
+		if (is2Byte(codePoint)) {
+			return "" + ((char) codePoint);
+		} else {
+			int u = codePoint - 0x1_0000;
+			return new String(new char[]{
+					(char) (((u >> 10) & 0b11_1111_1111) | highSurrogateBase),
+					(char) ((u & 0b11_1111_1111) | lowSurrogateBase)
+			});
+		}
+	}
+
+	/**
+	 * Converts a Unicode code-point to a string.
+	 */
+	public static void codePointToStr(int codePoint, StringBuilder collector) {
+		if (is2Byte(codePoint)) {
+			collector.append((char) codePoint);
+		} else {
+			int u = codePoint - 0x1_0000;
+			collector.append((char) (((u >> 10) & 0b11_1111_1111) | highSurrogateBase));
+			collector.append((char) ((u & 0b11_1111_1111) | lowSurrogateBase));
+		}
+	}
+}

--- a/test/unicode.aya
+++ b/test/unicode.aya
@@ -23,4 +23,59 @@
     [ 1  2  3  4  ]
 }
 
+{ "surrogate pairs as part of symbol names and strings" :P 1 1 }
+.# 0x10ffff (high=0x3ff, low=0x3ff)
+{ "􏿿" ::􏿿 :C }
+.# 10fc00 (high=0x3ff, low=0x0)
+{ "􏰀" ::􏰀 :C }
+.# 103ff (high=0x0, low=0x3ff)
+{ "𐏿" ::𐏿 :C }
+.# 10000 (high=0x0, low=0x0)
+{ "𐀀" ::𐀀 :C }
+.# 0xffff
+{ "￿" ::￿ :C }
+
+{ "assigning variables identified by surrogate pairs" :P 1 1 }
+.# [0x10ffff 10fc00 103ff 10000 0xffff]
+{
+    1:􏿿; 2:􏰀; 3:𐏿; 4:𐀀; 5:￿;
+    [1 2 3 4 5] [􏿿􏰀𐏿𐀀￿]
+}
+{
+    6:"􏿿"; 7:"􏰀"; 8:"𐏿"; 9:"𐀀"; 10:"￿";
+    [6 7 8 9 10] [􏿿􏰀𐏿𐀀￿]
+}
+
+{ "string to code-point conversions" :P 1 1 }
+{ [(:0x3ff 10.( :0x3ff | :0x10000+)] "􏿿" :(unicode.to_code_points) }
+{ [(:0x3ff 10.( :0x000 | :0x10000+)] "􏰀" :(unicode.to_code_points) }
+{ [(:0x000 10.( :0x3ff | :0x10000+)] "𐏿" :(unicode.to_code_points) }
+{ [(:0x000 10.( :0x000 | :0x10000+)] "𐀀" :(unicode.to_code_points) }
+{ [:0xffff] "￿" :(unicode.to_code_points) }
+{ "az"R:' "az"R :(unicode.to_code_points) }
+
+{ "code-point to string conversions" :P 1 1 }
+{ "􏿿" (:0x3ff 10.( :0x3ff | :0x10000+) :(unicode.from_code_points) }
+{ "􏰀" (:0x3ff 10.( :0x000 | :0x10000+) :(unicode.from_code_points) }
+{ "𐏿" (:0x000 10.( :0x3ff | :0x10000+) :(unicode.from_code_points) }
+{ "𐀀" (:0x000 10.( :0x000 | :0x10000+) :(unicode.from_code_points) }
+{ "￿" :0xffff :(unicode.from_code_points) }
+{ "az"R "az"R:' :(unicode.from_code_points) }
+
+{ "string to utf-16 code-unit conversions" :P 1 1 }
+{ [(:0xd800 :0x3ff+) (:0xdc00 :0x3ff+)] "􏿿" :(utf16.to_code_units) }
+{ [(:0xd800 :0x3ff+) (:0xdc00 :0x000+)] "􏰀" :(utf16.to_code_units) }
+{ [(:0xd800 :0x000+) (:0xdc00 :0x3ff+)] "𐏿" :(utf16.to_code_units) }
+{ [(:0xd800 :0x000+) (:0xdc00 :0x000+)] "𐀀" :(utf16.to_code_units) }
+{ [:0xffff] "￿" :(utf16.to_code_units) }
+{ "az"R:' "az"R :(utf16.to_code_units) }
+
+{ "utf-16 code-unit to string conversions" :P 1 1 }
+{ "􏿿" [(:0xd800 :0x3ff+) (:0xdc00 :0x3ff+)] :(utf16.from_code_units) }
+{ "􏰀" [(:0xd800 :0x3ff+) (:0xdc00 :0x000+)] :(utf16.from_code_units) }
+{ "𐏿" [(:0xd800 :0x000+) (:0xdc00 :0x3ff+)] :(utf16.from_code_units) }
+{ "𐀀" [(:0xd800 :0x000+) (:0xdc00 :0x000+)] :(utf16.from_code_units) }
+{ "￿" :0xffff :(utf16.from_code_units) }
+{ "az"R "az"R:' :(utf16.from_code_units) }
+
 ] :# {test.test}

--- a/test/unicode.aya
+++ b/test/unicode.aya
@@ -35,17 +35,6 @@
 .# 0xffff
 { "￿" ::￿ :C }
 
-{ "assigning variables identified by surrogate pairs" :P 1 1 }
-.# [0x10ffff 10fc00 103ff 10000 0xffff]
-{
-    1:􏿿; 2:􏰀; 3:𐏿; 4:𐀀; 5:￿;
-    [1 2 3 4 5] [􏿿􏰀𐏿𐀀￿]
-}
-{
-    6:"􏿿"; 7:"􏰀"; 8:"𐏿"; 9:"𐀀"; 10:"￿";
-    [6 7 8 9 10] [􏿿􏰀𐏿𐀀￿]
-}
-
 { "string to code-point conversions" :P 1 1 }
 { [(:0x3ff 10.( :0x3ff | :0x10000+)] "􏿿" :(unicode.to_code_points) }
 { [(:0x3ff 10.( :0x000 | :0x10000+)] "􏰀" :(unicode.to_code_points) }
@@ -77,5 +66,24 @@
 { "𐀀" [(:0xd800 :0x000+) (:0xdc00 :0x000+)] :(utf16.from_code_units) }
 { "￿" :0xffff :(utf16.from_code_units) }
 { "az"R "az"R:' :(utf16.from_code_units) }
+
+{ "symbols to tuples using utf-16 surrogate pairs" :P 1 1 }
+{ [ 'a 'b "foo" 'c "bar" "d" "e" ] :(utf16.to_tuples) [ "𨑢" "foo" "c" "bar" "𩁥" ] }
+
+{ "split tuples to their original symbols" :P 1 1 }
+{ [ "𨑢" "foo" "c" "bar" "𩁥" ] :(utf16.from_tuples) [ "a" "b" "foo" "c" "bar" "d" "e" ] }
+
+{ "assigning tuples" :P 1 1 }
+{ 1 2 :𨑢;; [𨑢] [1 2] }
+{ 3 4 :"𨑢";; 5 6 :"𩁥";; [𨑢𩁥] [3 4 5 6] }
+{ :{}:d; 7 8 d.:𨑢; d :{7:a; 8:b;} }
+{ "string interpolation with tuples" :P 1 1 }
+{ 9 10 :𨑢;; "$(𨑢)" "[ 9 10 ]" }
+{ ".~ for tuples" :P 1 1 }
+{ {𨑢}.~ ::"𨑢" }
+{ ":S for tuples" :P 1 1 }
+{ {𩁥}:S [::"𩁥"] }
+{ ".+ for tuples" :P 1 1 }
+{ {𨑢 x.𨑢} :{1 2:𨑢;} .+ P {1 2 x.𨑢} P }
 
 ] :# {test.test}


### PR DESCRIPTION
Resolves #147 

This extends support for Unicode characters to those that are encoded using surrogate pairs.

With the addition that these surrogate pairs refer to two separate variables. (see `variables_and_scope.md` or `unicode.aya` for reference)

This change should be backwards compatible, since surrogate pairs previously were (effectively) illegal in variable names.

---

### Edge Cases

Get-Index / Set-Index for Lists does not support tuples.

```
aya> [1 2]:l; 1 {1 -} :𨑢;; l.[𨑢]
Syntax Error: Invalid index: (a b). Currently, only single variable indices are supported.
[1 2]:l; 1 {1 -} :𨑢;; l.[𨑢]
~~~~~~~~~~~~~~~~~~~~~~~~^

aya> [1 2]:l; 1 {1 -} :𨑢;; 6 7 l.:[𨑢]
Syntax Error: Invalid index: (a b). Currently, only single variable indices are supported.
[1 2]:l; 1 {1 -} :𨑢;; "x" l.:[𨑢]
~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
```

Whereas wrapping in a lambda bypasses the optimization and works "normally". (For tuples that evaluate to a single value)
```
aya> [1 2]:l; 1 {1 -} :𨑢;; l.[(𨑢)]
1
aya> [1 2]:l; 1 {1 -} :𨑢;; "x" l.:[(𨑢)]
[ "x" 2 ]
```

---

### Behaviour changes

Previously the `.+ (BD)` operator behaved like this:

```
aya> {c.a b} :{1:a; 2:b;} .+
{c 1 2}
```

I think replacing the `GetKeyVariableInstruction` is accidental?  
I have changed it to behave like this:

```
aya> {c.a b} :{1:a; 2:b;} .+
{c .a 2}
```