### PR TITLE
Short circuit behavior for `&` and `|`

### DIFF
--- a/src/aya/ext/image/instruction/GetImageFormatsInstruction.java
+++ b/src/aya/ext/image/instruction/GetImageFormatsInstruction.java
@@ -1,18 +1,18 @@
 package aya.ext.image.instruction;
 
-import aya.eval.BlockEvaluator;
-import aya.instruction.named.NamedOperator;
-import aya.obj.Obj;
-import aya.obj.dict.Dict;
-import aya.obj.list.List;
-import aya.obj.list.Str;
-
-import javax.imageio.spi.IIORegistry;
-import javax.imageio.spi.ImageWriterSpi;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.stream.Collectors;
+
+import javax.imageio.spi.IIORegistry;
+import javax.imageio.spi.ImageWriterSpi;
+
+import aya.eval.BlockEvaluator;
+import aya.instruction.named.NamedOperator;
+import aya.obj.Obj;
+import aya.obj.list.List;
+import aya.obj.list.Str;
 
 public class GetImageFormatsInstruction extends NamedOperator {
 

--- a/src/aya/ext/plot/instruction/BoxPlotInstruction.java
+++ b/src/aya/ext/plot/instruction/BoxPlotInstruction.java
@@ -167,14 +167,15 @@ public class BoxPlotInstruction extends NamedOperator {
         input.renderConfig.renderChart(opName, chart);
     }
 
-    private static class BoxAndWhiskerItemWrapper extends BoxAndWhiskerItem {
+    @SuppressWarnings("serial")
+	private static class BoxAndWhiskerItemWrapper extends BoxAndWhiskerItem {
 
         public BoxAndWhiskerItemWrapper(BoxAndWhiskerItem other, boolean enableFarOutlier) {
             super(
                     other.getMean(), other.getMedian(), other.getQ1(), other.getQ3(),
                     other.getMinRegularValue(), other.getMaxRegularValue(),
-                    enableFarOutlier ? other.getMinOutlier() : new Double(Double.NEGATIVE_INFINITY),
-                    enableFarOutlier ? other.getMaxOutlier() : new Double(Double.POSITIVE_INFINITY),
+                    enableFarOutlier ? other.getMinOutlier() : Double.NEGATIVE_INFINITY,
+                    enableFarOutlier ? other.getMaxOutlier() : Double.POSITIVE_INFINITY,
                     other.getOutliers()
             );
         }

--- a/src/aya/instruction/op/MiscOps.java
+++ b/src/aya/instruction/op/MiscOps.java
@@ -8,8 +8,6 @@ import static aya.obj.Obj.NUMBER;
 import static aya.obj.Obj.STR;
 import static aya.util.Casting.asNumber;
 
-import java.util.ArrayList;
-
 import aya.StaticData;
 import aya.eval.BlockEvaluator;
 import aya.eval.ExecutionContext;

--- a/src/aya/obj/dict/Dict.java
+++ b/src/aya/obj/dict/Dict.java
@@ -315,7 +315,6 @@ public class Dict extends Obj {
 	
 	/** Return a string representation of the dict */
 	private String dictStr() {
-		final boolean fullStr = true;
 		ReprStream stream = new ReprStream();
 		stream.setFullStrings(true);
 		return dictRepr(stream).toString();//.toStringOneline();

--- a/src/ui/QuickSearch.java
+++ b/src/ui/QuickSearch.java
@@ -52,6 +52,7 @@ import ui.settings.QuickSearchSettings;
 import ui.settings.SettingsManager;
 
 
+@SuppressWarnings("serial")
 public class QuickSearch extends JPanel {
 	// Pro: this prevents the slow Swing rendering from blocking input, making the UI feel less laggy while typing.
 	// Con: UI might feel less responsive on fast machines.

--- a/src/ui/components/FixedTextPane.java
+++ b/src/ui/components/FixedTextPane.java
@@ -8,6 +8,7 @@ import java.awt.Rectangle;
 /**
  * Mirrors the reasonable overrides of {@link javax.swing.JTextArea} that were forgotten in all other Text Components...
  */
+@SuppressWarnings("serial")
 public class FixedTextPane extends JTextPane {
 	private int rowHeight = 0;
 	private int columnWidth = 0;

--- a/src/web/WebAvailableNamedInstructionStore.java
+++ b/src/web/WebAvailableNamedInstructionStore.java
@@ -1,7 +1,5 @@
 package web;
 
-import java.io.File;
-import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -13,7 +11,6 @@ import aya.instruction.named.NamedInstructionStore;
 import aya.instruction.named.NamedOperator;
 import aya.obj.list.List;
 import aya.obj.list.Str;
-import aya.util.FileUtils;
 
 public class WebAvailableNamedInstructionStore implements NamedInstructionStore {
 	/**

--- a/test/ops.aya
+++ b/test/ops.aya
@@ -4,6 +4,43 @@
 { [[1 2 3]] 0 I [1 2 3] }
 { [[1 2 3]] [0] I [[1 2 3]] }
 
+{ 1 1 & 1}
+{ 1 0 & 0}
+{ 0 1 & 0}
+{ 0 0 & 0}
+
+{ 1 1 | 1}
+{ 1 0 | 1}
+{ 0 1 | 1}
+{ 0 0 | 0}
+
+{ 1 {1} & 1}
+{ 1 {0} & 0}
+{ 0 {1} & 0}
+{ 0 {0} & 0}
+{ 1 {1} | 1}
+{ 1 {0} | 1}
+{ 0 {1} | 1}
+{ 0 {0} | 0}
+
+{ {1} {1} & 1}
+{ {1} {0} & 0}
+{ {0} {1} & 0}
+{ {0} {0} & 0}
+{ {1} {1} | 1}
+{ {1} {0} | 1}
+{ {0} {1} | 1}
+{ {0} {0} | 0}
+
+.# Short circuit, second condition is never evaluated
+{:x("a"), 0 {"b":x 1} & ; x "a"}
+.# Short circuit but second condition is evaluated since first condition is true
+{:x("a"), 1 {"b":x 1} & ; x "b"}
+.# Short circuit, second condition is never evaluated
+{:x("a"), 1 {"b":x 1} | ; x "a"}
+.# Short circuit but second condition is evaluated since first condition is false
+{:x("a"), 0 {"b":x 1} | ; x "b"}
+
 { [1] 2 L [ [1] [1] ] }
 { 1 2 L  [1 1] }
 { 0 [2 2] L [ [0 0] [0 0] ] }


### PR DESCRIPTION
This PR adds [short circuit evaluation](https://en.wikipedia.org/wiki/Short-circuit_evaluation) to `&` and `|`.

## Background

In many programming languages you can write code like below because if the first condition fails, it won't try to evaluate the second condition.

```python
# Python example

my_dict = {}

# No key error since the second condition is never evaluated
if 'my_key' in my_dict and my_dict['my_key'] == 1:
	...
```

There is no short circuiting in Aya so the equivalent check will throw a key error if the key is not in the dict

```
:{} :my_dict;

.# this will throw a key error!
my_dict "my_key" H my_dict.["my_key"] 1 = & {
	...
} ?
```

You can emulate short circuiting using a nested if/else like so but it isn't as obvious what is going on:

```
my_dict "my_key" H {my_dict.["my_key"] 1 =} {0} .? {
  ...
} ?
```

## Change

If the second arg to `&` or `|` is a block, only evaluate it if the first result is true/false respectively:

```
aya> 1 {"Hi":P 1} &
Hi
1
aya> 0 {"Hi":P 1} &
0
aya> 1 {"Hi":P 1} |
1
aya> 0 {"Hi":P 1} |
Hi
1
```

We can now write the example above as long as we wrap the second condition in a block:

```
:{} :my_dict;

.# No longer throws a key error!
my_dict "my_key" H {my_dict.["my_key"] 1 =} & {
	...
} ?
```

For consistency, the first arg may optionally also be a block
```
:{} :my_dict;
{my_dict "my_key" H} {my_dict.["my_key"] 1 =} & {
	...
} ?
```

Chain example using the fold operator:

```
aya> [{"a":P 1} {"b":P 1} {"c":P 1} {"d":P 1}] {&} %
a
b
c
d
1
aya> [{"a":P 1} {"b":P 0} {"c":P 1} {"d":P 1}] {&} %
a
b
0
```