### PR TITLE
Fix editor window deadlock

### DIFF
--- a/src/aya/AyaThread.java
+++ b/src/aya/AyaThread.java
@@ -79,6 +79,12 @@ public class AyaThread extends Thread {
 		}
 	}
 	
+	public ExecutionResult waitForResponseBlocked() throws InterruptedException, ThreadError {
+		ExecutionResult res = _output.take();
+		_pending_task_count--;
+		return res;
+	}
+	
 	public ExecutionResult eval(ExecutionRequest request) {
 		ExecutionResult result;
 		BlockEvaluator b = _root.createEvaluator();

--- a/src/ui/EditorWindow.java
+++ b/src/ui/EditorWindow.java
@@ -217,17 +217,6 @@ public class EditorWindow extends JPanel {
 		StaticBlock blk = Parser.compileSafeOrNull(new SourceString(txt, "<editor>"), StaticData.IO);
 		if (blk != null) {
 			_aya.queueInput(new ExecutionRequest(99999, blk)); // TODO change req id
-			
-			// This is kind of broken since the REPL and this window are using the same AyaThread
-			// This call could be getting a task from the REPL and is not guaranteed to be the one we just sent
-			try {
-				ExecutionResult res = _aya.waitForResponse();
-				InteractiveAya.printResult(StaticData.IO, res, false);
-			} catch (ThreadError e) {
-				StaticData.IO.err().print(e.getMessage());
-			} catch (InterruptedException e) {
-				e.printStackTrace(StaticData.IO.err());
-			}
 		}
 	}
 	


### PR DESCRIPTION
Move blocking code out of editor window. All requests are processed in the same processing loop.

Fixes #108 

Test case:

Open editor window and run the following code:

```
import dialog
"test" dialog.alert
```

Note that requests are still processed in sequence by the main thread so only one alert box will appear at a time if you run the editor window multiple times. All inputs will be queued though