### PR TITLE
Block self reference

### DIFF
--- a/examples/canvas/circles.aya
+++ b/examples/canvas/circles.aya
@@ -10,14 +10,15 @@ require canvas {canvas}
     1:autoflush
 } canvas! :c;
 
-{x::num y::num radius::num,
+.# * creates a self reference to this function named f
+{x::num y::num radius::num : f*,
     radius 4 > {
         x y radius c.circle
 
-        (x radius 2 / +, y, radius 2 /) drawcircle
-        (x radius 2 / -, y, radius 2 /) drawcircle
-        (x, y radius 2 / +, radius 2 /) drawcircle
-        (x, y radius 2 / -, radius 2 /) drawcircle
+        (x radius 2 / +, y, radius 2 /) f
+        (x radius 2 / -, y, radius 2 /) f
+        (x, y radius 2 / +, radius 2 /) f
+        (x, y radius 2 / -, radius 2 /) f
         1 :Z .# animate
     } ?
 }:drawcircle;

--- a/examples/fibonacci.aya
+++ b/examples/fibonacci.aya
@@ -1,6 +1,6 @@
 .# Golfed stack based version
 {
-0\1{$@+}@%;
+    0\1{$@+}@%;
 }:fib_stack;
 
 "" :P
@@ -27,11 +27,13 @@
 "15 fib_iter is $(15 fib_iter)" :P
 
 .# Classic recursive algorithm
-{n,
-    n 0 = n 1 = | {
+.# * creates a self reference to this function named f
+{n : f*,
+    .# Parenthesis are optional in Aya; they are sometimes useful for readability
+    (n 0 =) (n 1 =) | {
         n
     } {
-        n 1 - fib_rec n 2 - fib_rec +
+        (n 1 -)f (n 2 -)f +
     } .?
 }:fib_rec;
 

--- a/manual/blocks_and_functions.md
+++ b/manual/blocks_and_functions.md
@@ -71,42 +71,7 @@ aya> 2:n 3{n, n2^}~ n
 
 ## Argument Type Assertions
 
-Arguments may have type assertions. Write a variable name followed by a symbol corresponding to the type.
-
-```
-1 2 {a::num b::num, a b +}~    .# => 3
-"1" 2 {a::num b::num, a b +}~   .# TYPE ERROR: Type error at ({ARGS}):
-                             Expected (::num)
-                             Recieved ("1" )
-```
-
-If a user defined type defines a `type` variable as a symbol. The symbol will be used for type assertions.
-
-```
-:{
-  ::vec :type;
-
-  ... define vec variables and functions ...
-}:vec;
-
-{v::vec,
-  v :P
-}:printvec;
-```
-
-The type checker will use the `.type` variable:
-
-```
-aya> 1 2 vec! :v
-<1,2>
-aya> v printvec
-<1,2>
-aya> 3 printvec
-TYPE ERROR: Type error at ({ARGS}):
-	Expected (::vec)
-	Recieved (3 )
-```
-
+See *Type Annotations* page.
 
 ## Local Declarations
 
@@ -152,6 +117,30 @@ aya> .# define a as a list which evaluates to l
 aya> {: a([l]), a} ~
 [ 99 ]
 ```
+
+## Self Reference
+
+Use `*` in the local declarations section to create a self reference. The name does not need to match the name of the function
+
+```
+{n : f*,
+    .# Parenthesis are optional in Aya; they are sometimes useful for readability
+    (n 0 =) (n 1 =) | {
+        n
+    } {
+        (n 1 -)f (n 2 -)f +
+    } .?
+}:fib_rec;
+```
+
+
+For golfing purposes, providing a name is optional and will default to `f` is not provided.
+
+```
+aya> {:*, }
+{: f({...}),}
+```
+
 
 ## Keyword Arguments
 

--- a/src/aya/instruction/BlockLiteralInstruction.java
+++ b/src/aya/instruction/BlockLiteralInstruction.java
@@ -22,14 +22,16 @@ public class BlockLiteralInstruction extends Instruction {
 	HashMap<Symbol, StaticBlock> _defaults;
 	boolean _auto_eval;
 	CheckReturnTypeGenerator _ret_type;
+	Symbol _self_reference;
 	
-	public BlockLiteralInstruction(SourceStringRef source, StaticBlock b, HashMap<Symbol, StaticBlock> defaults, CheckReturnTypeGenerator ret_type) {
+	public BlockLiteralInstruction(SourceStringRef source, StaticBlock b, HashMap<Symbol, StaticBlock> defaults, CheckReturnTypeGenerator ret_type, Symbol self_reference) {
 		super(source);
 		if (defaults != null && defaults.size() == 0) _defaults = null;
 		_block = b;
 		_defaults = defaults;
 		_auto_eval = false;
 		_ret_type = ret_type;
+		_self_reference = self_reference;
 	
 		// If the instruction has locals, make sure the underlying blockEvaluator has them as well
 		if (_defaults != null) {
@@ -53,15 +55,17 @@ public class BlockLiteralInstruction extends Instruction {
 		StaticBlock blk = BlockUtils.copySetTypeInfo(_block, _ret_type, b.getContext());
 
 		// If there are defaults, evaluate them and push a new blockEvaluator
-		if (_defaults != null) {
+		if (_defaults != null || _self_reference != null) {
 			Dict defaults = new Dict();
-			for (Symbol var : _defaults.keySet()) {
-				BlockEvaluator evaluator = b.getContext().createEvaluator();
-				evaluator.dump(_defaults.get(var));
-				evaluator.eval();
-				defaults.set(var, evaluator.pop());
+			if (_defaults != null) {
+				for (Symbol var : _defaults.keySet()) {
+					BlockEvaluator evaluator = b.getContext().createEvaluator();
+					evaluator.dump(_defaults.get(var));
+					evaluator.eval();
+					defaults.set(var, evaluator.pop());
+				}
 			}
-			blk = BlockUtils.mergeLocals(blk, defaults);
+			blk = BlockUtils.mergeLocals(blk, defaults, _self_reference);
 		}
 		
 		
@@ -75,7 +79,7 @@ public class BlockLiteralInstruction extends Instruction {
 	@Override
 	public ReprStream repr(ReprStream stream) {
 		if (_auto_eval) stream.print("(");
-		BlockUtils.repr(stream, _block, true, _defaults);
+		BlockUtils.repr(stream, _block, true, _defaults, _self_reference);
 		if (_auto_eval) stream.print(")");
 		return stream;
 	}

--- a/src/aya/instruction/DictLiteralInstruction.java
+++ b/src/aya/instruction/DictLiteralInstruction.java
@@ -85,7 +85,7 @@ public class DictLiteralInstruction extends Instruction {
 	@Override
 	public ReprStream repr(ReprStream stream) {
 		stream.print(":");
-		BlockUtils.repr(stream, _block, true, null);
+		BlockUtils.repr(stream, _block, true, null, null);
 		return stream;
 	}
 }

--- a/src/aya/instruction/index/GetExprIndexInstruction.java
+++ b/src/aya/instruction/index/GetExprIndexInstruction.java
@@ -21,7 +21,7 @@ public class GetExprIndexInstruction extends GetIndexInstruction {
 	@Override
 	public ReprStream repr(ReprStream stream) {
 		stream.print(".[");
-		BlockUtils.repr(stream, _index, false, null);
+		BlockUtils.repr(stream, _index, false, null, null);
 		stream.print("]");
 		return stream;
 	}

--- a/src/aya/instruction/op/ColonOps.java
+++ b/src/aya/instruction/op/ColonOps.java
@@ -872,7 +872,7 @@ class OP_Colon_M extends Operator {
 	public OP_Colon_M() {
 		init(":M");
 		arg("DD", "set D1's meta to D2 leave D1 on stack");
-		arg("BD", "update a copy of the blockEvaluator locals with the dict");
+		arg("BD", "update a copy of the blockEvaluator locals with the dict. Warning: since this creates a copy, a pre-existing self reference will point to the original block");
 	}
 
 	@Override
@@ -884,7 +884,7 @@ class OP_Colon_M extends Operator {
 			((Dict)obj).setMetaTable((Dict)meta);
 			blockEvaluator.push(obj);
 		} else if(obj.isa(BLOCK) && meta.isa(DICT)) {
-			StaticBlock new_block = BlockUtils.mergeLocals(Casting.asStaticBlock(obj), asDict(meta));
+			StaticBlock new_block = BlockUtils.mergeLocals(Casting.asStaticBlock(obj), asDict(meta), null);
 			blockEvaluator.push(new_block);
 		} else {
 			throw new TypeError(this, meta, obj);

--- a/src/aya/instruction/variable/assignment/TypedAssignment.java
+++ b/src/aya/instruction/variable/assignment/TypedAssignment.java
@@ -93,7 +93,7 @@ public class TypedAssignment extends CopyAssignment {
 			s.setTight(true);
 			s.print(super.toString());
 			s.print("::");
-			BlockUtils.repr(s, _type_block, false, null);
+			BlockUtils.repr(s, _type_block, false, null, null);
 			return s.toStringOneline();
 		} else {
 			return "::any";

--- a/src/aya/obj/block/StaticBlock.java
+++ b/src/aya/obj/block/StaticBlock.java
@@ -112,12 +112,12 @@ public class StaticBlock extends Obj {
 
 	@Override
 	public ReprStream repr(ReprStream stream) {
-		return BlockUtils.repr(stream, this, true, null);
+		return BlockUtils.repr(stream, this, true, null, null);
 	}
 
 	@Override
 	public String str() {
-		return BlockUtils.repr(new ReprStream(), this, true, null).toStringOneline();
+		return BlockUtils.repr(new ReprStream(), this, true, null, null).toStringOneline();
 	}
 
 	@Override

--- a/src/aya/obj/symbol/SymbolConstants.java
+++ b/src/aya/obj/symbol/SymbolConstants.java
@@ -12,6 +12,8 @@ public class SymbolConstants {
 	public static final Symbol G 		= S("g");
 	public static final Symbol B 		= S("b");
 	public static final Symbol A 		= S("a");
+	public static final Symbol F 		= S("f");
+
 
 	public static final Symbol ANY 		= S("any");
 	public static final Symbol CHAR 	= S("char");

--- a/src/aya/parser/token/TokenQueue.java
+++ b/src/aya/parser/token/TokenQueue.java
@@ -25,6 +25,10 @@ public class TokenQueue  {
 		queue.add(t);
 	}
 	
+	public void addFront(Token t) {
+		queue.add(0, t);
+	}
+	
 	public void replaceNext(Token t) {
 		queue.set(0, t);
 	}

--- a/src/aya/parser/tokens/BlockToken.java
+++ b/src/aya/parser/tokens/BlockToken.java
@@ -47,7 +47,7 @@ public class BlockToken extends CollectionToken {
 					InstructionStack main_instructions = Parser.generate(blockData.get(1));
 					var h = HeaderUtils.generateBlockHeader(blockData.get(0));
 					StaticBlock blk = BlockUtils.fromIS(main_instructions, h.locals, h.args);
-					return new BlockLiteralInstruction(this.getSourceStringRef(), blk, h.captures, h.ret_types);
+					return new BlockLiteralInstruction(this.getSourceStringRef(), blk, h.captures, h.ret_types, h.self_reference);
 				}
 			} else {
 				throw new SyntaxError("BlockEvaluator contains too many parts", getSourceStringRef());


### PR DESCRIPTION
Use `*` in the local declarations section to create a self reference. The name does not need to match the name of the function

```
{n : f*,
    .# Parenthesis are optional in Aya; they are sometimes useful for readability
    (n 0 =) (n 1 =) | {
        n
    } {
        (n 1 -)f (n 2 -)f +
    } .?
}:fib_rec;
```


For golfing purposes, providing a name is optional and will default to `f` is not provided.

```
aya> {a b : * c d, }
{a b : c(0) d(0) f({...}),}

aya> {:*, }
{: f({...}),}
```

The `*` can appear after any name (just like `^`)

```
{arg_a arg_b : local_a capture_a^ self_ref* local_b capture_b^ ... , ...}
```