### PR TITLE
Remove xml instruction from web build

### DIFF
--- a/src/web/AyaWeb.java
+++ b/src/web/AyaWeb.java
@@ -22,9 +22,9 @@ import aya.io.stdin.EmptyInputWrapper;
 public class AyaWeb {
 
 	private static final StringOut output = new StringOut();
-	
+
     public static void main(String[] args) {
-    	
+
     	//
     	// Set up StaticData
     	//
@@ -35,10 +35,10 @@ public class AyaWeb {
 				new PrintStream(output.getErrStream()),
 				null,
 				new EmptyInputWrapper());
-		
+
 		WebFilesystemIO fs = new WebFilesystemIO();
 		StaticData.FILESYSTEM = fs;
-		
+
 		//
 		// Named Instructions
 		// Web build only supports a limited set of named instructions
@@ -47,7 +47,6 @@ public class AyaWeb {
 		WebAvailableNamedInstructionStore wsi = new WebAvailableNamedInstructionStore();
 		sd.addNamedInstructionStore(wsi);
 		sd.addNamedInstructionStore(new JSONInstructionStore());
-		sd.addNamedInstructionStore(new XmlInstructionStore());
 		sd.addNamedInstructionStore(new DateInstructionStore());
 		sd.addNamedInstructionStore(new ColorInstructionStore());
 		sd.addNamedInstructionStore(new LinearAlgebraInstructionStore());
@@ -59,11 +58,11 @@ public class AyaWeb {
 			StandaloneAya.runIsolated(s, StaticData.IO);
 			return output.flushOut() + output.flushErr();
 		});
-    	
+
     	exportAddFile((path, content) -> ((WebFilesystemIO)(StaticData.FILESYSTEM)).addFile(path, content));
-    	
+
     	exportListFiles(() -> String.join(",", fs.listFiles()));
-    	
+
     	exportLint(source -> {
 			ArrayList<ParserException> errors = StandaloneAya.lint(source);
 			if (errors.size() > 0) {
@@ -75,13 +74,13 @@ public class AyaWeb {
 				return "";
 			}
 		});
-    	
+
     }
-    
+
     //
     // Exported Functions
     //
-    
+
     @JSBody(params = "runIsolated", script = "main.runIsolated = runIsolated;")
     private static native void exportRunIsolated(ExportFunctionRunIsolated fn);
 


### PR DESCRIPTION
xml lib uses some `javax` classes which aren't compatible. Removing from web instructions for now.

```
mvn package -P web

```

```
[ERROR] Class javax.xml.transform.TransformerFactory was not found
    at aya.ext.xml.ToXmlInstruction.dictToXmlStr(ToXmlInstruction.java:68)
    at aya.ext.xml.ToXmlInstruction.execute(ToXmlInstruction.java:62)
    at aya.instruction.named.NamedOperatorInstruction.execute(NamedOperatorInstruction.java:35)
    at aya.eval.BlockEvaluator.eval(BlockEvaluator.java:152)
    at aya.StandaloneAya.runIsolated(StandaloneAya.java:70)
    at web.AyaWeb.lambda$main$0(AyaWeb.java:59)
    at web.AyaWeb$main$lambda$_1_0.call(AyaWeb.java:58)
    at web.AyaWeb$main$lambda$_1_0.call$exported$0
[ERROR] Class javax.xml.transform.Transformer was not found
    at aya.ext.xml.ToXmlInstruction.dictToXmlStr(ToXmlInstruction.java:69)
    at aya.ext.xml.ToXmlInstruction.execute(ToXmlInstruction.java:62)
    at aya.instruction.named.NamedOperatorInstruction.execute(NamedOperatorInstruction.java:35)
    at aya.eval.BlockEvaluator.eval(BlockEvaluator.java:152)
    at aya.StandaloneAya.runIsolated(StandaloneAya.java:70)
    at web.AyaWeb.lambda$main$0(AyaWeb.java:59)
    at web.AyaWeb$main$lambda$_1_0.call(AyaWeb.java:58)
    at web.AyaWeb$main$lambda$_1_0.call$exported$0
[ERROR] Class javax.xml.transform.Transformer was not found
    at aya.ext.xml.ToXmlInstruction.dictToXmlStr(ToXmlInstruction.java:71)
    at aya.ext.xml.ToXmlInstruction.execute(ToXmlInstruction.java:62)
    at aya.instruction.named.NamedOperatorInstruction.execute(NamedOperatorInstruction.java:35)
    at aya.eval.BlockEvaluator.eval(BlockEvaluator.java:152)
    at aya.StandaloneAya.runIsolated(StandaloneAya.java:70)
    at web.AyaWeb.lambda$main$0(AyaWeb.java:59)
    at web.AyaWeb$main$lambda$_1_0.call(AyaWeb.java:58)
    at web.AyaWeb$main$lambda$_1_0.call$exported$0
[ERROR] Class javax.xml.parsers.DocumentBuilderFactory was not found
    at aya.ext.xml.LoadXmlInstruction.parseXml(LoadXmlInstruction.java:84)
    at aya.ext.xml.LoadXmlInstruction.execute(LoadXmlInstruction.java:79)
    at aya.instruction.named.NamedOperatorInstruction.execute(NamedOperatorInstruction.java:35)
    at aya.eval.BlockEvaluator.eval(BlockEvaluator.java:152)
    at aya.StandaloneAya.runIsolated(StandaloneAya.java:70)
    at web.AyaWeb.lambda$main$0(AyaWeb.java:59)
    at web.AyaWeb$main$lambda$_1_0.call(AyaWeb.java:58)
    at web.AyaWeb$main$lambda$_1_0.call$exported$0
```